### PR TITLE
Use SupervisorJob() instead of regular Job() in MainScope

### DIFF
--- a/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BaseModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BaseModel.kt
@@ -4,7 +4,7 @@ import co.touchlab.kampstarter.printThrowable
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.KoinComponent
 import kotlin.coroutines.CoroutineContext
 
@@ -22,7 +22,7 @@ internal class MainScope(private val mainContext: CoroutineContext) : CoroutineS
     override val coroutineContext: CoroutineContext
         get() = mainContext + job + exceptionHandler
 
-    internal val job = Job()
+    internal val job = SupervisorJob()
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         showError(throwable)
     }


### PR DESCRIPTION
See https://kotlinlang.org/docs/reference/coroutines/exception-handling.html#supervision for details on how these differ. `SupervisorJob` is generally useful as a top-level scope for things like ViewModels and similar UI components because a failure of one of its child jobs won't cancel the other children.