### PR TITLE
Add Objective-C generics compiler flag

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     kotlin("multiplatform")
@@ -28,6 +29,7 @@ kotlin {
     }else{
         iosX64("ios")
     }
+    targets.getByName<KotlinNativeTarget>("ios").compilations["main"].kotlinOptions.freeCompilerArgs += "-Xobjc-generics"
 
     version = "1.0"
 
@@ -108,7 +110,7 @@ val iOSTest: Task by tasks.creating {
     description = "Runs tests for target 'ios' on an iOS simulator"
 
     doLast {
-        val binary = kotlin.targets.getByName<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget>("ios").binaries.getTest("DEBUG").outputFile
+        val binary = kotlin.targets.getByName<KotlinNativeTarget>("ios").binaries.getTest("DEBUG").outputFile
         exec {
             commandLine("xcrun", "simctl", "spawn", "--standalone",device, binary.absolutePath)
         }


### PR DESCRIPTION
Addresses #55 

Note we'll need to adjust this if/when we return to using `ios()` to generate targets since there won't be a target named "ios" anymore