### PR TITLE
Fix common test compile error in BreedModelTest.kt

### DIFF
--- a/shared/src/commonTest/kotlin/co/touchlab/kampstarter/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampstarter/BreedModelTest.kt
@@ -17,9 +17,11 @@ abstract class BreedModelTest {
     fun setup(){
         TestingServiceRegistry.appStart(dbHelper,settings,ktorApi)
 
-        model = BreedModel{
-
-        }
+        model = BreedModel(viewUpdate = { _ ->
+            // TODO: Test callback invocation
+        }, errorUpdate = { _ ->
+            // TODO: Test callback invocation
+        })
     }
 
     @Test


### PR DESCRIPTION
Fixes `BreedModelTest` compile error by adding stub functions for the `viewUpdate` and `errorUpdate` constructor params.

Not exactly what I would call "good test coverage" but at least it resolves the compile error for now. I'll follow up with a commit to to ensure success/failure callbacks are properly invoked.