### PR TITLE
Supply explicit delegates on Settings initialization

### DIFF
--- a/shared/src/androidMain/kotlin/co/touchlab/kampstarter/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/co/touchlab/kampstarter/KoinAndroid.kt
@@ -1,7 +1,10 @@
 package co.touchlab.kampstarter
 
+import android.content.Context
+import android.content.SharedPreferences
 import co.touchlab.kampstarter.db.KampstarterDb
 import com.russhwolf.settings.AndroidSettings
+import com.russhwolf.settings.Settings
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
 import org.koin.core.module.Module
@@ -16,5 +19,10 @@ actual val platformModule: Module = module {
         )
     }
 
-    single { AndroidSettings.Factory(get()).create("KAMPSTARTER_SETTINGS") }
+    single<Settings> {
+        val context: Context = get()
+        val preferences: SharedPreferences =
+            context.getSharedPreferences("KAMPSTARTER_SETTINGS", Context.MODE_PRIVATE)
+        AndroidSettings(preferences)
+    }
 }

--- a/shared/src/iosMain/kotlin/co/touchlab/kampstarter/KoiniOS.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampstarter/KoiniOS.kt
@@ -2,12 +2,17 @@ package co.touchlab.kampstarter
 
 import co.touchlab.kampstarter.db.KampstarterDb
 import com.russhwolf.settings.AppleSettings
+import com.russhwolf.settings.Settings
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.drivers.ios.NativeSqliteDriver
 import org.koin.dsl.module
+import platform.Foundation.NSUserDefaults
 
 fun initKoin() = initKoin{}
 actual val platformModule = module {
-    single { AppleSettings.Factory().create("KAMPSTARTER_SETTINGS") }
+    single<Settings> {
+        val userDefaults = NSUserDefaults(suiteName = "KAMPSTARTER_SETTINGS")
+        AppleSettings(userDefaults)
+    }
     single<SqlDriver> { NativeSqliteDriver(KampstarterDb.Schema, "kampstarterdb") }
 }


### PR DESCRIPTION
I think this is a better model for how people integrating into existing projects will want things configured. They may have any arbitrary existing SharedPreferences or UserDefaults instance, so this makes explicit how that can be accessed from shared code.