### PR TITLE
Set Coroutine Compiler Flag

### DIFF
--- a/app/src/main/java/co/touchlab/kampstarter/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampstarter/android/MainActivity.kt
@@ -7,9 +7,7 @@ import co.touchlab.kampstarter.android.adapter.MainAdapter
 import co.touchlab.kampstarter.models.BreedModel
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@ExperimentalCoroutinesApi
 class MainActivity : AppCompatActivity() {
     companion object {
         val TAG = MainActivity::class.java.simpleName

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("multiplatform")
@@ -32,6 +33,14 @@ kotlin {
         listOf("-Xobjc-generics", "-Xg0")
 
     version = "1.1"
+
+    sourceSets {
+        all {
+            languageSettings.apply {
+                useExperimentalAnnotation("kotlinx.coroutines.ExperimentalCoroutinesApi")
+            }
+        }
+    }
 
     sourceSets["commonMain"].dependencies {
         implementation(kotlin("stdlib-common", Versions.kotlin))

--- a/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BreedModel.kt
@@ -8,14 +8,12 @@ import co.touchlab.kampstarter.sqldelight.asFlow
 import co.touchlab.stately.ensureNeverFrozen
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.core.inject
 
-@ExperimentalCoroutinesApi
 class BreedModel(private val viewUpdate: (ItemDataSummary) -> Unit,
                  private val errorUpdate: (String) -> Unit) : BaseModel() {
     private val dbHelper: DatabaseHelper by inject()


### PR DESCRIPTION
By adding a compiler flag, we can avoid adding the annotation whenever we use experimental features. Closes #82 