### PR TITLE
Join BreedModel Calls in tests

### DIFF
--- a/app/src/main/java/co/touchlab/kampstarter/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampstarter/android/MainActivity.kt
@@ -1,7 +1,7 @@
 package co.touchlab.kampstarter.android
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.touchlab.kampstarter.android.adapter.MainAdapter
 import co.touchlab.kampstarter.models.BreedModel
@@ -26,7 +26,7 @@ class MainActivity : AppCompatActivity() {
             Snackbar.make(breed_list, errorMessage, Snackbar.LENGTH_SHORT).show()
         })
 
-        adapter = MainAdapter(model::updateBreedFavorite)
+        adapter = MainAdapter { model.updateBreedFavorite(it) }
 
         breed_list.adapter = adapter
         breed_list.layoutManager = LinearLayoutManager(this)

--- a/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampstarter/models/BreedModel.kt
@@ -50,9 +50,8 @@ class BreedModel(
         }
 
         val currentTimeMS = currentTimeMillis()
-        var job: Job = Job().apply { complete() }
-        if (isBreedListStale(currentTimeMS)) {
-            job = ktorScope.launch {
+        return if (isBreedListStale(currentTimeMS)) {
+            ktorScope.launch {
                 try {
                     val breedResult = ktorApi.getJsonFromApi()
                     val breedList = breedResult.message.keys.toList()
@@ -62,8 +61,9 @@ class BreedModel(
                     errorUpdate("Unable to download breed list")
                 }
             }
+        } else {
+            Job().apply { complete() }
         }
-        return job
     }
 
     private fun insertBreedData(breeds: List<String>) = mainScope.launch {

--- a/shared/src/commonTest/kotlin/co/touchlab/kampstarter/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampstarter/BreedModelTest.kt
@@ -35,18 +35,18 @@ class BreedModelTest: BaseTest() {
     fun staleDataCheckTest() = runTest {
         settings.putLong(BreedModel.DB_TIMESTAMP_KEY, currentTimeMillis())
         assertFalse(ktorApi.jsonRequested)
-        model.getBreedsFromNetwork()
+        model.getBreedsFromNetwork().join()
         assertFalse(ktorApi.jsonRequested)
     }
 
     @Test
     fun updateFavoriteTest() = runTest {
-        model.getBreedsFromNetwork()
+        model.getBreedsFromNetwork().join()
         itemDataSummary.await(500)
         val breedOld = dbHelper.selectAllItems().executeAsList().first()
         assertEquals("appenzeller", breedOld.name)
         assertFalse(breedOld.isFavorited())
-        model.updateBreedFavorite(breedOld)
+        model.updateBreedFavorite(breedOld).join()
         val breedNew = dbHelper.selectById(breedOld.id).executeAsOne()
         assertTrue(breedNew.isFavorited())
     }
@@ -55,7 +55,7 @@ class BreedModelTest: BaseTest() {
     fun notifyErrorOnException() = runTest {
         ktorApi.thowOnRequest = true
 
-        model.getBreedsFromNetwork()
+        model.getBreedsFromNetwork().join()
         val error = errorString.await(500)
         assertNotNull(error)
     }


### PR DESCRIPTION
Expose the Job created when we launch coroutines in BreedModel. These are ignored in production, but allows us to wait for them to join in the tests. This will hopefully reduce errors in CI that we aren't seeing locally