### PR TITLE
Greater memory safety on iOS side

### DIFF
--- a/ios/KaMPStarteriOS/ViewController.swift
+++ b/ios/KaMPStarteriOS/ViewController.swift
@@ -15,30 +15,47 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     var data:[Breed] = []
     
     private var model: BreedModel?
+    
+    // MARK: View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
         breedTableView.delegate = self
         breedTableView.dataSource = self
 
-        model = BreedModel(viewUpdate: {summary in
-            self.data = summary.allItems
-            self.breedTableView.reloadData()
-        },errorUpdate: { errorMessage in
-            let alertController = UIAlertController(title: "error", message: errorMessage, preferredStyle: .actionSheet)
-            alertController.addAction(UIAlertAction(title: "Dismiss", style: .default))
-            self.present(alertController, animated: true, completion: nil)
-        })
+        model = BreedModel(
+            viewUpdate: { [weak self] summary in
+                self?.viewUpdate(for: summary)
+            }, errorUpdate: { [weak self] errorMessage in
+                self?.errorUpdate(for: errorMessage)
+            }
+        )
         
         //We check for stalk data in this method
-        model!.getBreedsFromNetwork()
+        model?.getBreedsFromNetwork()
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        self.model?.onDestroy()
-        self.model = nil
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        model?.onDestroy()
+        model = nil
     }
     
+    // MARK: BreedModel Closures
+    
+    private func viewUpdate(for summary: ItemDataSummary) {
+        data = summary.allItems
+        breedTableView.reloadData()
+    }
+    
+    private func errorUpdate(for errorMessage: String) {
+        let alertController = UIAlertController(title: "error", message: errorMessage, preferredStyle: .actionSheet)
+        alertController.addAction(UIAlertAction(title: "Dismiss", style: .default))
+        present(alertController, animated: true, completion: nil)
+    }
+    
+    // MARK: TableView
+        
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return data.count
     }

--- a/ios/KaMPStarteriOS/ViewController.swift
+++ b/ios/KaMPStarteriOS/ViewController.swift
@@ -35,8 +35,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         model?.getBreedsFromNetwork()
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         model?.onDestroy()
         model = nil
     }


### PR DESCRIPTION
- Added [weak self] up to closures for safer memory
- self now optional inside of closures
- moved closure functionality out to separate functions for readability
- noticed onDestroy() being called in viewWillDisappear(), felt weird for model to be gone before view is no longer visible
- also noticed super was not called on viewWillDisappear(), added it to viewDidDisappear()
- added some MARK statements for organization