### PR TITLE
Add workaround for "import shared" issue on bitrise

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -25,6 +25,8 @@ sdk.dir=/Users/[YOUR_USER_NAME]/Library/Android/sdk
 
 **A:** Try closing Xcode and deleting the `Pods/` folder located in the root directory of the iOS project. Then run the command `pod install` in that same iOS root directory (which is `/KaMPStarter/ios/` to be specific). This command will generate a new `Pods` folder. Reopen the `.xcworkspace` file and try to build again.
 
+If you happen to randomly see this in **bitrise CI**, try to disable the *Disable built-in cache* option in the **Run Cocoapods install** step options.
+
 > Note: We're still not quite sure as to the cause of this error. Possible factors include differing versions of Cocoapods or >Xcode.
 
 ## More to Come!


### PR DESCRIPTION
As bitrise is a quite popular CI for mobile developers I thought it might make sense to add a workaround for the dreaded `import shared` `no such module: 'shared'` issue. 

On bitrise it happens randomly (though quite often - 2 out of 3 builds for me) and seems to be caused by the caching implemented in the **Run Cocoapods install** step - steps are predefined, shareable units of work in bitrise build scripts and the Cocoapods step is (for a reason) a very popular one. Disabling the caching option fixed the issue for me and it didn't pop up again since.