### PR TITLE
Clear warning around @OptIn usage

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings.apply {
+                useExperimentalAnnotation("kotlin.RequiresOptIn")
                 useExperimentalAnnotation("kotlinx.coroutines.ExperimentalCoroutinesApi")
             }
         }


### PR DESCRIPTION
Clearing the warning around OptIn usage [here](https://github.com/touchlab/KaMPKit/blob/master/shared/src/iosMain/kotlin/co/touchlab/kampkit/ktor/Platform.kt#L20) (and also saving downstream users from needing to add this themselves if they have other opt-ins)