### PR TITLE
[ios] Allow injection into Koin from iOS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ allprojects {
         maven(url = "https://kotlin.bintray.com/kotlinx")
         maven(url = "https://dl.bintray.com/ekito/koin")
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
+        maven(url = "https://dl.bintray.com/suparnatural/kotlin-multiplatform")
     }
 }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -22,6 +22,7 @@ object Versions {
     val karmok = "0.1.7"
     val ktlint_gradle_plugin = "9.2.1"
     val robolectric = "4.3.1"
+    val concurrency = "1.0.10"
 }
 
 object Deps {
@@ -88,5 +89,12 @@ object Deps {
         val commonSerialization ="io.ktor:ktor-client-serialization:${Versions.ktor}"
         val androidSerialization ="io.ktor:ktor-client-serialization-jvm:${Versions.ktor}"
         val iosSerialization ="io.ktor:ktor-client-serialization-native:${Versions.ktor}"
+    }
+
+    object Concurrency {
+        val common = "suparnatural-kotlin-multiplatform:concurrency-metadata:${Versions.concurrency}"
+        val android = "suparnatural-kotlin-multiplatform:concurrency-android:${Versions.concurrency}"
+        val iosX64 = "suparnatural-kotlin-multiplatform:concurrency-iosx64:${Versions.concurrency}"
+        val iosArm64 = "suparnatural-kotlin-multiplatform:concurrency-iosarm64:${Versions.concurrency}"
     }
 }

--- a/ios/KaMPKitiOS/AppDelegate.swift
+++ b/ios/KaMPKitiOS/AppDelegate.swift
@@ -13,9 +13,16 @@ import shared
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
-    let log = KoinIOS().get(objCClass: Kermit.self, parameter: "AppDelegate") as! Kermit
+    
+    // lazy initialize since AppDelegate is instantiated before we run init on KoinIOS
+    lazy var log = KoinIOS().get(objCClass: Kermit.self, parameter: "AppDelegate") as! Kermit
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        // Initialize Koin depedency injection
+        let userDefaults = UserDefaults(suiteName: "KAMPSTARTER_SETTINGS")!
+        KoinIOS().initialize(userDefaults: userDefaults)
+        
         // Override point for customization after application launch.
         log.v(withMessage: {"App Started"})
         return true

--- a/ios/KaMPKitiOS/ViewController.swift
+++ b/ios/KaMPKitiOS/ViewController.swift
@@ -14,7 +14,9 @@ class BreedsViewController: UIViewController {
     @IBOutlet weak var breedTableView: UITableView!
     var data: [Breed] = []
     
-    let log = KoinIOS().get(objCClass: Kermit.self, parameter: "ViewController") as! Kermit
+    // load lazily as we're using storyboards and the instantiation lifecycle happens
+    // before we can setup KoinIOS inside the AppDelegate.
+    lazy var log = KoinIOS().get(objCClass: Kermit.self, parameter: "ViewController") as! Kermit
     
     lazy var adapter: NativeViewModel = NativeViewModel(
         viewUpdate: { [weak self] summary in

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
         implementation(Deps.multiplatformSettings)
         implementation(Deps.koinCore)
         implementation(Deps.Ktor.commonSerialization)
+        implementation(Deps.Concurrency.common)
         api(Deps.kermit)
     }
 
@@ -79,6 +80,7 @@ kotlin {
         implementation(Deps.Coroutines.android)
         implementation(Deps.Ktor.androidSerialization)
         implementation(Deps.Ktor.androidCore)
+        implementation(Deps.Concurrency.android)
     }
 
     sourceSets["androidTest"].dependencies {
@@ -105,6 +107,13 @@ kotlin {
         }
         implementation(Deps.Ktor.iosSerialization)
         implementation(Deps.koinCore)
+
+        val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos")?:false
+        if (onPhone) {
+            implementation(Deps.Concurrency.iosArm64)
+        } else {
+            implementation(Deps.Concurrency.iosX64)
+        }
     }
 
     cocoapodsext {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -108,7 +108,7 @@ kotlin {
         implementation(Deps.Ktor.iosSerialization)
         implementation(Deps.koinCore)
 
-        val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos")?:false
+        val onPhone = System.getenv("SDK_NAME")?.startsWith("iphoneos") ?: false
         if (onPhone) {
             implementation(Deps.Concurrency.iosArm64)
         } else {

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
@@ -4,6 +4,7 @@ import co.touchlab.kampkit.db.KaMPKitDb
 import co.touchlab.kermit.Kermit
 import co.touchlab.kermit.NSLogLogger
 import com.russhwolf.settings.AppleSettings
+import com.russhwolf.settings.Settings
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import com.suparnatural.core.concurrency.Immutability
@@ -28,7 +29,7 @@ object KoinIOS {
     fun initialize(userDefaults: NSUserDefaults) {
         koin = initKoin {
             modules(module {
-                single { AppleSettings(userDefaults) }
+                single<Settings> { AppleSettings(userDefaults) }
             })
         }
     }

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
@@ -28,9 +28,11 @@ object KoinIOS {
 
     fun initialize(userDefaults: NSUserDefaults) {
         koin = initKoin {
-            modules(module {
-                single<Settings> { AppleSettings(userDefaults) }
-            })
+            modules(
+                module {
+                    single<Settings> { AppleSettings(userDefaults) }
+                }
+            )
         }
     }
 

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
@@ -4,21 +4,18 @@ import co.touchlab.kampkit.db.KaMPKitDb
 import co.touchlab.kermit.Kermit
 import co.touchlab.kermit.NSLogLogger
 import com.russhwolf.settings.AppleSettings
-import com.russhwolf.settings.Settings
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
+import com.suparnatural.core.concurrency.Immutability
 import kotlinx.cinterop.ObjCClass
 import kotlinx.cinterop.getOriginalKotlinClass
+import org.koin.core.KoinApplication
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.Qualifier
 import org.koin.dsl.module
 import platform.Foundation.NSUserDefaults
 
 actual val platformModule = module {
-    single<Settings> {
-        val userDefaults = NSUserDefaults(suiteName = "KAMPKIT_SETTINGS")
-        AppleSettings(userDefaults)
-    }
     single<SqlDriver> { NativeSqliteDriver(KaMPKitDb.Schema, "KampkitDb") }
 
     val baseKermit = Kermit(NSLogLogger()).withTag("KampKit")
@@ -26,20 +23,28 @@ actual val platformModule = module {
 }
 
 object KoinIOS {
-    val koin = initKoin { }
+    private var koin: KoinApplication? by Immutability(null)
+
+    fun initialize(userDefaults: NSUserDefaults) {
+        koin = initKoin {
+            modules(module {
+                single { AppleSettings(userDefaults) }
+            })
+        }
+    }
 
     fun get(objCClass: ObjCClass, qualifier: Qualifier?, parameter: Any): Any {
         val kClazz = getOriginalKotlinClass(objCClass)!!
-        return koin.koin.get(kClazz, qualifier) { parametersOf(parameter) }
+        return koin!!.koin.get(kClazz, qualifier) { parametersOf(parameter) }
     }
 
     fun get(objCClass: ObjCClass, parameter: Any): Any {
         val kClazz = getOriginalKotlinClass(objCClass)!!
-        return koin.koin.get(kClazz, null) { parametersOf(parameter) }
+        return koin!!.koin.get(kClazz, null) { parametersOf(parameter) }
     }
 
     fun get(objCClass: ObjCClass, qualifier: Qualifier?): Any {
         val kClazz = getOriginalKotlinClass(objCClass)!!
-        return koin.koin.get(kClazz, qualifier, null)
+        return koin!!.koin.get(kClazz, qualifier, null)
     }
 }


### PR DESCRIPTION
This updates the project to allow injection directly from iOS similar to how Android can as seen in: `MainApp.kt`.
Fixes #113 

**NOTES:**
These changes introduce a library to allow us to have a shared object while still being able to mutate it. I think it's not the most ideal setup but it's a good tradeoff for the clean interface to the developer and seeing that this will only be set once. However, I'm open to other suggestions.