### PR TITLE
Migrate synthetic extensions and findViewById to ViewBinding

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
-
 plugins {
     id("com.android.application")
     kotlin("android")
@@ -38,23 +36,22 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
     implementation(project(":shared"))
-    implementation(Deps.recyclerView)
-    implementation(Deps.material_x)
-    implementation(Deps.app_compat_x)
-    implementation(Deps.core_ktx)
+    implementation(Deps.AndroidX.recyclerView)
+    implementation(Deps.material)
+    implementation(Deps.AndroidX.appcompat)
+    implementation(Deps.AndroidX.core_ktx)
     implementation(Deps.Ktor.androidCore)
-    implementation(Deps.constraintlayout)
+    implementation(Deps.AndroidX.constraintlayout)
     implementation(Deps.SqlDelight.runtimeJdk)
     implementation(Deps.SqlDelight.driverAndroid)
     implementation(Deps.Coroutines.common)
     implementation(Deps.Coroutines.android)
     implementation(Deps.multiplatformSettings)
     implementation(Deps.koinCore)
-    implementation(Deps.lifecycle_viewmodel)
-    implementation(Deps.lifecycle_viewmodel_extensions)
-    implementation(Deps.lifecycle_livedata)
-    implementation(Deps.lifecycle_extension)
+    implementation(Deps.AndroidX.lifecycle_viewmodel)
+    implementation(Deps.AndroidX.lifecycle_viewmodel_extensions)
+    implementation(Deps.AndroidX.lifecycle_livedata)
+    implementation(Deps.AndroidX.lifecycle_extension)
     testImplementation(Deps.junit)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
 }
 
 android {
@@ -32,6 +31,10 @@ android {
     lintOptions {
         isWarningsAsErrors = true
         isAbortOnError = true
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 }
 

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -2,52 +2,43 @@ package co.touchlab.kampkit.android
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.touchlab.kampkit.android.adapter.MainAdapter
+import co.touchlab.kampkit.android.databinding.ActivityMainBinding
 import co.touchlab.kermit.Kermit
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.activity_main.*
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.koin.core.parameter.parametersOf
 
 class MainActivity : AppCompatActivity(), KoinComponent {
-    companion object {
-        val TAG = MainActivity::class.java.simpleName
-    }
-    private lateinit var adapter: MainAdapter
+
+    private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
+
     private val log: Kermit by inject { parametersOf("MainActivity") }
 
     private lateinit var viewModel: BreedViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        setContentView(binding.root)
 
         viewModel = ViewModelProviders.of(this).get(BreedViewModel::class.java)
+        val adapter = MainAdapter { viewModel.updateBreedFavorite(it) }
 
-        viewModel.breedLiveData.observe(
-            this,
-            Observer { itemData ->
-                log.v { "List submitted to adapter" }
-                adapter.submitList(itemData.allItems)
-            }
-        )
-        viewModel.errorLiveData.observe(
-            this,
-            Observer { errorMessage ->
-                log.e { "Error displayed: $errorMessage" }
-                Snackbar.make(breed_list, errorMessage, Snackbar.LENGTH_SHORT).show()
-            }
-        )
-        adapter = MainAdapter {
-            viewModel.updateBreedFavorite(it)
+        viewModel.breedLiveData.observe(this) { itemData ->
+            log.v { "List submitted to adapter" }
+            adapter.submitList(itemData.allItems)
         }
 
-        breed_list.adapter = adapter
-        breed_list.layoutManager = LinearLayoutManager(this)
+        viewModel.errorLiveData.observe(this) { errorMessage ->
+            log.e { "Error displayed: $errorMessage" }
+            Snackbar.make(binding.breedList, errorMessage, Snackbar.LENGTH_SHORT).show()
+        }
+
+        binding.breedList.adapter = adapter
+        binding.breedList.layoutManager = LinearLayoutManager(this)
 
         viewModel.getBreedsFromNetwork()
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/adapter/MainAdapter.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/adapter/MainAdapter.kt
@@ -4,17 +4,15 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import co.touchlab.kampkit.android.R
+import co.touchlab.kampkit.android.databinding.ItemBreedBinding
 import co.touchlab.kampkit.db.Breed
 
 class MainAdapter(private val breedClickListener: (Breed) -> Unit) :
-    ListAdapter<Breed, MainViewHolder>(
-        breedCallback
-    ) {
+    ListAdapter<Breed, MainViewHolder>(breedCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MainViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_breed, parent, false)
-        return MainViewHolder(view) {
+        val binding = ItemBreedBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return MainViewHolder(binding) {
             breedClickListener(getItem(it))
         }
     }
@@ -25,12 +23,9 @@ class MainAdapter(private val breedClickListener: (Breed) -> Unit) :
 
     companion object {
         private val breedCallback = object : DiffUtil.ItemCallback<Breed>() {
-            override fun areContentsTheSame(oldItem: Breed, newItem: Breed): Boolean =
-                (oldItem.id == newItem.id) &&
-                    (oldItem.favorite == newItem.favorite)
+            override fun areContentsTheSame(oldItem: Breed, newItem: Breed): Boolean = oldItem == newItem
 
-            override fun areItemsTheSame(oldItem: Breed, newItem: Breed): Boolean =
-                oldItem.id == newItem.id
+            override fun areItemsTheSame(oldItem: Breed, newItem: Breed): Boolean = oldItem.id == newItem.id
         }
     }
 }

--- a/app/src/main/java/co/touchlab/kampkit/android/adapter/MainViewHolder.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/adapter/MainViewHolder.kt
@@ -1,16 +1,15 @@
 package co.touchlab.kampkit.android.adapter
 
-import android.view.View
-import android.widget.ImageButton
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import co.touchlab.kampkit.android.R
+import co.touchlab.kampkit.android.databinding.ItemBreedBinding
 import co.touchlab.kampkit.db.Breed
 
-class MainViewHolder(itemView: View, breedClickListener: (Int) -> Unit) : RecyclerView.ViewHolder(itemView) {
+class MainViewHolder(binding: ItemBreedBinding, breedClickListener: (Int) -> Unit) :
+    RecyclerView.ViewHolder(binding.root) {
 
-    private val nameTextView = itemView.findViewById<TextView>(R.id.breed_name_text_view)
-    private val favoriteButton = itemView.findViewById<ImageButton>(R.id.favorite_button)
+    private val nameTextView = binding.breedNameTextView
+    private val favoriteButton = binding.favoriteButton
 
     init {
         favoriteButton.setOnClickListener { breedClickListener(adapterPosition) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,7 @@ allprojects {
         mavenCentral()
         jcenter()
         maven(url = "https://kotlin.bintray.com/kotlinx")
-        //maven(url = "https://dl.bintray.com/ekito/koin") TODO: revert when Koin is available
-        maven(url = "https://dl.bintray.com/touchlabpublic/kotlin")
+        maven(url = "https://dl.bintray.com/ekito/koin")
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
     }
 }
@@ -53,6 +52,6 @@ subprojects {
     }
 }
 
-tasks.register("clean", Delete::class) {
+tasks.register<Delete>("clean") {
     delete(rootProject.buildDir)
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,89 +1,97 @@
 object Versions {
     val min_sdk = 21
-    val target_sdk = 29
-    val compile_sdk = 29
+    val target_sdk = 30
+    val compile_sdk = 30
 
-    val kotlin = "1.4.0"
-    val androidx_test = "1.2.0"
-    val androidx_test_ext = "1.1.1"
-    val android_gradle_plugin = "3.6.3"
-    val buildToolsVersion = "29.0.0"
-    val junit = "4.13"
-    val sqlDelight = "1.4.4"
-    val ktor = "1.4.0"
-    val stately = "1.1.0"
-    val multiplatformSettings = "0.6.1"
-    val coroutines = "1.3.9-native-mt"
-    val koin = "3.0.1-alpha-2"
-    val serialization = "1.0.0-RC"
+    val kotlin = "1.4.10"
+    val android_gradle_plugin = "4.0.1"
+
+    val buildToolsVersion = "30.0.2"
     val cocoapodsext = "0.11"
+    val coroutines = "1.3.9-native-mt-2"
     val kermit = "0.1.8"
-    val lifecycle = "2.1.0"
     val karmok = "0.1.8"
-    val ktlint_gradle_plugin = "9.2.1"
-    val robolectric = "4.3.1"
+    val koin = "3.0.0-alpha-4"
+    val ktlint_gradle_plugin = "9.4.1"
+    val ktor = "1.4.2"
+    val junit = "4.13"
+    val material = "1.2.1"
+    val multiplatformSettings = "0.6.3"
+    val robolectric = "4.4"
+    val sqlDelight = "1.4.4"
+    val stately = "1.1.0"
+    val serialization = "1.0.0"
+
+    object AndroidX {
+        val appcompat = "1.2.0"
+        val constraintlayout = "2.0.4"
+        val core = "1.3.2"
+        val lifecycle = "2.2.0"
+        val recyclerview = "1.1.0"
+        val test = "1.3.0"
+        val test_ext = "1.1.2"
+    }
 }
 
 object Deps {
-    val app_compat_x = "androidx.appcompat:appcompat:1.1.0"
-    val material_x = "com.google.android.material:material:1.1.0"
-    val core_ktx = "androidx.core:core-ktx:1.2.0"
-    val constraintlayout = "androidx.constraintlayout:constraintlayout:1.1.3"
-    val recyclerView = "androidx.recyclerview:recyclerview:1.1.0"
     val android_gradle_plugin = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
+    val cocoapodsext = "co.touchlab:kotlinnativecocoapods:${Versions.cocoapodsext}"
     val junit = "junit:junit:${Versions.junit}"
-    val stately = "co.touchlab:stately-common:${Versions.stately}"
-    val multiplatformSettings = "com.russhwolf:multiplatform-settings:${Versions.multiplatformSettings}"
-    val multiplatformSettingsTest = "com.russhwolf:multiplatform-settings-test:${Versions.multiplatformSettings}"
+    val material = "com.google.android.material:material:${Versions.material}"
+    val karmok = "co.touchlab:karmok-library:${Versions.karmok}"
+    val kermit = "co.touchlab:kermit:${Versions.kermit}"
     val koinCore = "org.koin:koin-core:${Versions.koin}"
     val koinTest = "org.koin:koin-test:${Versions.koin}"
-    val cocoapodsext = "co.touchlab:kotlinnativecocoapods:${Versions.cocoapodsext}"
-    val kermit = "co.touchlab:kermit:${Versions.kermit}"
-    val lifecycle_viewmodel = "android.arch.lifecycle:viewmodel:${Versions.lifecycle}"
-    val lifecycle_viewmodel_extensions = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.lifecycle}"
-    val lifecycle_livedata = "android.arch.lifecycle:livedata:${Versions.lifecycle}"
-    val lifecycle_extension = "android.arch.lifecycle:extensions:${Versions.lifecycle}"
-    val karmok = "co.touchlab:karmok-library:${Versions.karmok}"
+    val multiplatformSettings = "com.russhwolf:multiplatform-settings:${Versions.multiplatformSettings}"
+    val multiplatformSettingsTest = "com.russhwolf:multiplatform-settings-test:${Versions.multiplatformSettings}"
     val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
+    val stately = "co.touchlab:stately-common:${Versions.stately}"
+
+    object AndroidX {
+        val appcompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}"
+        val core_ktx = "androidx.core:core-ktx:${Versions.AndroidX.core}"
+        val constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.AndroidX.constraintlayout}"
+        val recyclerView = "androidx.recyclerview:recyclerview:${Versions.AndroidX.recyclerview}"
+        val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.AndroidX.lifecycle}"
+        val lifecycle_viewmodel_extensions = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.AndroidX.lifecycle}"
+        val lifecycle_livedata = "androidx.lifecycle:lifecycle-livedata:${Versions.AndroidX.lifecycle}"
+        val lifecycle_extension = "androidx.lifecycle:lifecycle-extensions:${Versions.AndroidX.lifecycle}"
+    }
 
     object AndroidXTest {
-        val core = "androidx.test:core:${Versions.androidx_test}"
-        val junit = "androidx.test.ext:junit:${Versions.androidx_test_ext}"
-        val runner = "androidx.test:runner:${Versions.androidx_test}"
-        val rules = "androidx.test:rules:${Versions.androidx_test}"
+        val core = "androidx.test:core:${Versions.AndroidX.test}"
+        val junit = "androidx.test.ext:junit:${Versions.AndroidX.test_ext}"
+        val runner = "androidx.test:runner:${Versions.AndroidX.test}"
+        val rules = "androidx.test:rules:${Versions.AndroidX.test}"
     }
 
     object KotlinTest {
-        val common =      "org.jetbrains.kotlin:kotlin-test-common:${Versions.kotlin}"
+        val common = "org.jetbrains.kotlin:kotlin-test-common:${Versions.kotlin}"
         val annotations = "org.jetbrains.kotlin:kotlin-test-annotations-common:${Versions.kotlin}"
-        val jvm =         "org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}"
-        val junit =       "org.jetbrains.kotlin:kotlin-test-junit:${Versions.kotlin}"
+        val jvm = "org.jetbrains.kotlin:kotlin-test:${Versions.kotlin}"
+        val junit = "org.jetbrains.kotlin:kotlin-test-junit:${Versions.kotlin}"
     }
+
     object Coroutines {
         val common = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
         val android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
         val test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
     }
-    object SqlDelight{
+
+    object SqlDelight {
         val gradle = "com.squareup.sqldelight:gradle-plugin:${Versions.sqlDelight}"
         val runtime = "com.squareup.sqldelight:runtime:${Versions.sqlDelight}"
         val runtimeJdk = "com.squareup.sqldelight:runtime-jvm:${Versions.sqlDelight}"
         val driverIos = "com.squareup.sqldelight:native-driver:${Versions.sqlDelight}"
         val driverAndroid = "com.squareup.sqldelight:android-driver:${Versions.sqlDelight}"
     }
+
     object Ktor {
         val commonCore = "io.ktor:ktor-client-core:${Versions.ktor}"
         val commonJson = "io.ktor:ktor-client-json:${Versions.ktor}"
         val commonLogging = "io.ktor:ktor-client-logging:${Versions.ktor}"
-        val jvmCore =     "io.ktor:ktor-client-core-jvm:${Versions.ktor}"
         val androidCore = "io.ktor:ktor-client-okhttp:${Versions.ktor}"
-        val jvmJson =     "io.ktor:ktor-client-json-jvm:${Versions.ktor}"
-        val jvmLogging =     "io.ktor:ktor-client-logging-jvm:${Versions.ktor}"
-        val ios =         "io.ktor:ktor-client-ios:${Versions.ktor}"
-        val iosCore =     "io.ktor:ktor-client-core-native:${Versions.ktor}"
-        val iosJson =     "io.ktor:ktor-client-json-native:${Versions.ktor}"
-        val iosLogging =     "io.ktor:ktor-client-logging-native:${Versions.ktor}"
-        val commonSerialization ="io.ktor:ktor-client-serialization:${Versions.ktor}"
-        val androidSerialization ="io.ktor:ktor-client-serialization-jvm:${Versions.ktor}"
+        val ios = "io.ktor:ktor-client-ios:${Versions.ktor}"
+        val commonSerialization = "io.ktor:ktor-client-serialization:${Versions.ktor}"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Tell the KMM plugin where the iOS project lives
+xcodeproj=./ios

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion(29)
+    compileSdkVersion(Versions.compile_sdk)
     defaultConfig {
         minSdkVersion(Versions.min_sdk)
         targetSdkVersion(Versions.target_sdk)
@@ -44,12 +44,15 @@ kotlin {
     }
 
     sourceSets["commonMain"].dependencies {
-        implementation(kotlin("stdlib-common", Versions.kotlin))
         implementation(Deps.SqlDelight.runtime)
         implementation(Deps.Ktor.commonCore)
         implementation(Deps.Ktor.commonJson)
         implementation(Deps.Ktor.commonLogging)
-        implementation(Deps.Coroutines.common)
+        implementation(Deps.Coroutines.common) {
+            version {
+                strictly(Versions.coroutines)
+            }
+        }
         implementation(Deps.stately)
         implementation(Deps.multiplatformSettings)
         implementation(Deps.koinCore)
@@ -69,11 +72,7 @@ kotlin {
     sourceSets["androidMain"].dependencies {
         implementation(kotlin("stdlib", Versions.kotlin))
         implementation(Deps.SqlDelight.driverAndroid)
-        implementation(Deps.Ktor.jvmCore)
-        implementation(Deps.Ktor.jvmJson)
-        implementation(Deps.Ktor.jvmLogging)
         implementation(Deps.Coroutines.android)
-        implementation(Deps.Ktor.androidSerialization)
         implementation(Deps.Ktor.androidCore)
     }
 
@@ -91,12 +90,6 @@ kotlin {
     sourceSets["iosMain"].dependencies {
         implementation(Deps.SqlDelight.driverIos)
         implementation(Deps.Ktor.ios)
-        implementation(Deps.Coroutines.common) {
-            version {
-                strictly(Versions.coroutines)
-            }
-        }
-        implementation(Deps.koinCore)
     }
 
     cocoapodsext {

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -13,7 +13,12 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
 import io.ktor.http.takeFrom
 
-class DogApiImpl(private val log: Kermit) : KtorApi {
+class DogApiImpl(log: Kermit) : KtorApi {
+
+    // If this is a constructor property, then it gets captured inside HttpClient config and freezes this whole class
+    @Suppress("CanBePrimaryConstructorProperty")
+    private val log = log
+
     private val client = HttpClient {
         install(JsonFeature) {
             serializer = KotlinxSerializer()

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -12,7 +12,7 @@ import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.koin.core.parameter.parametersOf
 
-class BreedModel() : KoinComponent {
+class BreedModel : KoinComponent {
     private val dbHelper: DatabaseHelper by inject()
     private val settings: Settings by inject()
     private val ktorApi: KtorApi by inject()
@@ -53,6 +53,7 @@ class BreedModel() : KoinComponent {
                 dbHelper.insertBreeds(breedList)
                 settings.putLong(DB_TIMESTAMP_KEY, currentTimeMS)
             } catch (e: Exception) {
+                log.e(e) { "Error downloading breed list" }
                 return "Unable to download breed list"
             }
         } else {


### PR DESCRIPTION
I started doing this as part of the dependency updates but realized it should be its own thing. Not super necessary but might as well keep Android things up-to-date too.