### PR TITLE
Fixed: ViewModelProviders.of is deprecated

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,5 +56,6 @@ dependencies {
     implementation(Deps.AndroidX.lifecycle_viewmodel_extensions)
     implementation(Deps.AndroidX.lifecycle_livedata)
     implementation(Deps.AndroidX.lifecycle_extension)
+    implementation(Deps.AndroidX.koin_viewmodel)
     testImplementation(Deps.junit)
 }

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -2,12 +2,12 @@ package co.touchlab.kampkit.android
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModelProviders
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.touchlab.kampkit.android.adapter.MainAdapter
 import co.touchlab.kampkit.android.databinding.ActivityMainBinding
 import co.touchlab.kermit.Kermit
 import com.google.android.material.snackbar.Snackbar
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.koin.core.parameter.parametersOf
@@ -18,13 +18,12 @@ class MainActivity : AppCompatActivity(), KoinComponent {
 
     private val log: Kermit by inject { parametersOf("MainActivity") }
 
-    private lateinit var viewModel: BreedViewModel
+    private val viewModel: BreedViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        viewModel = ViewModelProviders.of(this).get(BreedViewModel::class.java)
         val adapter = MainAdapter { viewModel.updateBreedFavorite(it) }
 
         viewModel.breedLiveData.observe(this) { itemData ->

--- a/app/src/main/java/co/touchlab/kampkit/android/MainApp.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainApp.kt
@@ -6,6 +6,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import co.touchlab.kampkit.AppInfo
 import co.touchlab.kampkit.initKoin
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 class MainApp : Application() {
@@ -14,6 +15,7 @@ class MainApp : Application() {
         initKoin(
             module {
                 single<Context> { this@MainApp }
+                viewModel { BreedViewModel() }
                 single<SharedPreferences> {
                     get<Context>().getSharedPreferences("KAMPSTARTER_SETTINGS", Context.MODE_PRIVATE)
                 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -56,6 +56,7 @@ object Deps {
         val lifecycle_viewmodel_extensions = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.AndroidX.lifecycle}"
         val lifecycle_livedata = "androidx.lifecycle:lifecycle-livedata:${Versions.AndroidX.lifecycle}"
         val lifecycle_extension = "androidx.lifecycle:lifecycle-extensions:${Versions.AndroidX.lifecycle}"
+        val koin_viewmodel = "org.koin:koin-androidx-viewmodel:${Versions.koin}"
     }
 
     object AndroidXTest {


### PR DESCRIPTION
- Added Koin AndroidX ViewModels helper lib
- Vm is now registered in koin and is set by the delegate