### PR TITLE
Issue 152: Remove asFlow() in CoroutinesExtensions.kt

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -84,6 +84,7 @@ object Deps {
     object SqlDelight {
         val gradle = "com.squareup.sqldelight:gradle-plugin:${Versions.sqlDelight}"
         val runtime = "com.squareup.sqldelight:runtime:${Versions.sqlDelight}"
+        val coroutinesExtensions = "com.squareup.sqldelight:coroutines-extensions:${Versions.sqlDelight}"
         val runtimeJdk = "com.squareup.sqldelight:runtime-jvm:${Versions.sqlDelight}"
         val driverIos = "com.squareup.sqldelight:native-driver:${Versions.sqlDelight}"
         val driverAndroid = "com.squareup.sqldelight:android-driver:${Versions.sqlDelight}"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
 
     sourceSets["commonMain"].dependencies {
         implementation(Deps.SqlDelight.runtime)
+        implementation(Deps.SqlDelight.coroutinesExtensions)
         implementation(Deps.Ktor.commonCore)
         implementation(Deps.Ktor.commonJson)
         implementation(Deps.Ktor.commonLogging)

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -2,11 +2,11 @@ package co.touchlab.kampkit
 
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.db.KaMPKitDb
-import co.touchlab.kampkit.sqldelight.mapToList
 import co.touchlab.kampkit.sqldelight.transactionWithContext
 import co.touchlab.kermit.Kermit
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.runtime.coroutines.asFlow
+import com.squareup.sqldelight.runtime.coroutines.mapToList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -2,11 +2,11 @@ package co.touchlab.kampkit
 
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.db.KaMPKitDb
-import co.touchlab.kampkit.sqldelight.asFlow
 import co.touchlab.kampkit.sqldelight.mapToList
 import co.touchlab.kampkit.sqldelight.transactionWithContext
 import co.touchlab.kermit.Kermit
 import com.squareup.sqldelight.db.SqlDriver
+import com.squareup.sqldelight.runtime.coroutines.asFlow
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
@@ -1,23 +1,9 @@
 package co.touchlab.kampkit.sqldelight
 
-import com.squareup.sqldelight.Query
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.TransactionWithoutReturn
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.jvm.JvmOverloads
-
-@JvmOverloads
-internal fun <T : Any> Flow<Query<T>>.mapToList(
-    context: CoroutineContext = Dispatchers.Default
-): Flow<List<T>> = map {
-    withContext(context) {
-        it.executeAsList()
-    }
-}
 
 suspend fun Transacter.transactionWithContext(
     coroutineContext: CoroutineContext,

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
@@ -6,47 +6,9 @@ import com.squareup.sqldelight.TransactionWithoutReturn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmOverloads
-
-@JvmOverloads
-internal fun <T : Any> Flow<Query<T>>.mapToOne(
-    context: CoroutineContext = Dispatchers.Default
-): Flow<T> = map {
-    withContext(context) {
-        it.executeAsOne()
-    }
-}
-
-@JvmOverloads
-internal fun <T : Any> Flow<Query<T>>.mapToOneOrDefault(
-    defaultValue: T,
-    context: CoroutineContext = Dispatchers.Default
-): Flow<T> = map {
-    withContext(context) {
-        it.executeAsOneOrNull() ?: defaultValue
-    }
-}
-
-@JvmOverloads
-internal fun <T : Any> Flow<Query<T>>.mapToOneOrNull(
-    context: CoroutineContext = Dispatchers.Default
-): Flow<T?> = map {
-    withContext(context) {
-        it.executeAsOneOrNull()
-    }
-}
-
-@JvmOverloads
-internal fun <T : Any> Flow<Query<T>>.mapToOneNotNull(
-    context: CoroutineContext = Dispatchers.Default
-): Flow<T> = mapNotNull {
-    withContext(context) {
-        it.executeAsOneOrNull()
-    }
-}
 
 @JvmOverloads
 internal fun <T : Any> Flow<Query<T>>.mapToList(

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
@@ -1,48 +1,15 @@
 package co.touchlab.kampkit.sqldelight
 
-import co.touchlab.stately.freeze
 import com.squareup.sqldelight.Query
 import com.squareup.sqldelight.Transacter
 import com.squareup.sqldelight.TransactionWithoutReturn
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
-import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
-
-/**
- * Turns this [Query] into a [Flow] which emits whenever the underlying result set changes.
- *
- * Note: We copied this from the sqldelight repo because we're using the new native coroutines draft version.
- * When that is live, we'll be using the official sqldelight version.
- */
-@JvmName("toFlow")
-internal fun <T : Any> Query<T>.asFlow(): Flow<Query<T>> = flow {
-    emit(this@asFlow)
-
-    val channel = Channel<Unit>(CONFLATED).freeze()
-    val listener = object : Query.Listener {
-        override fun queryResultsChanged() {
-            channel.offer(Unit)
-        }
-    }
-
-    addListener(listener)
-    try {
-        for (item in channel) {
-            emit(this@asFlow)
-        }
-    } finally {
-        println("****** Closing Flow in removeListener ******")
-        removeListener(listener)
-    }
-}
 
 @JvmOverloads
 internal fun <T : Any> Flow<Query<T>>.mapToOne(


### PR DESCRIPTION
[Summary]
We use a custom extension method to convert a Query into a flow. This is
because at the time, SQLDelight's asFlow() method didn't use the new
native coroutines draft version, which we needed.

[Fix]
SQLDelight's coroutines extensions now use the new native coroutines
version. We can now replacing custom asFlow() extension method with SQLDelight's official
coroutines extensions library.

[Testing]
Manually tested Android and iOS apps for correct behavior.

https://github.com/touchlab/KaMPKit/issues/152