### PR TITLE
Issue 161: MVVM -> MVI, LiveData -> StateFlow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(Deps.Coroutines.android)
     implementation(Deps.multiplatformSettings)
     implementation(Deps.koinCore)
+    implementation(Deps.AndroidX.lifecycle_runtime)
     implementation(Deps.AndroidX.lifecycle_viewmodel)
     implementation(Deps.AndroidX.lifecycle_viewmodel_extensions)
     implementation(Deps.AndroidX.lifecycle_livedata)

--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -1,19 +1,24 @@
 package co.touchlab.kampkit.android
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.models.BreedModel
+import co.touchlab.kampkit.models.DataState
 import co.touchlab.kampkit.models.ItemDataSummary
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class BreedViewModel : ViewModel() {
 
     private var breedModel: BreedModel = BreedModel()
-    val breedLiveData = MutableLiveData<ItemDataSummary>()
-    val errorLiveData = MutableLiveData<String>()
+    private val _breedStateFlow: MutableStateFlow<DataState<ItemDataSummary>> = MutableStateFlow(
+        DataState.Loading
+    )
+
+    val breedStateFlow: StateFlow<DataState<ItemDataSummary>> = _breedStateFlow
 
     init {
         observeBreeds()
@@ -21,16 +26,16 @@ class BreedViewModel : ViewModel() {
 
     private fun observeBreeds() {
         viewModelScope.launch {
-            breedModel.selectAllBreeds().collect {
-                breedLiveData.postValue(it)
+            breedModel.getBreedsFromCache().collect {
+                _breedStateFlow.value = it
             }
         }
     }
 
-    fun getBreedsFromNetwork() {
+    fun getBreeds() {
         viewModelScope.launch {
-            breedModel.getBreedsFromNetwork()?.let { errorString ->
-                errorLiveData.postValue(errorString)
+            breedModel.getBreeds().collect {
+                _breedStateFlow.value = it
             }
         }
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -54,7 +54,6 @@ class MainActivity : AppCompatActivity(), KoinComponent {
             }
         )
 
-
         binding.breedList.adapter = adapter
         binding.breedList.layoutManager = LinearLayoutManager(this)
 
@@ -69,8 +68,8 @@ class MainActivity : AppCompatActivity(), KoinComponent {
     ) {
         lifecycleScope.launch {
             viewModel.breedStateFlow.collect {
-                    dataState ->
-                when(dataState) {
+                dataState ->
+                when (dataState) {
                     is DataState.Success -> {
                         onSuccess(dataState.data.allItems)
                     }
@@ -84,7 +83,6 @@ class MainActivity : AppCompatActivity(), KoinComponent {
                         onLoading()
                     }
                 }
-
             }
         }
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -2,11 +2,16 @@ package co.touchlab.kampkit.android
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import co.touchlab.kampkit.android.adapter.MainAdapter
 import co.touchlab.kampkit.android.databinding.ActivityMainBinding
+import co.touchlab.kampkit.db.Breed
+import co.touchlab.kampkit.models.DataState
 import co.touchlab.kermit.Kermit
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.KoinComponent
 import org.koin.core.inject
@@ -26,19 +31,61 @@ class MainActivity : AppCompatActivity(), KoinComponent {
 
         val adapter = MainAdapter { viewModel.updateBreedFavorite(it) }
 
-        viewModel.breedLiveData.observe(this) { itemData ->
-            log.v { "List submitted to adapter" }
-            adapter.submitList(itemData.allItems)
-        }
+        collectDataStateFlow(
+            {
+                /* Display loading view */
+            },
+            { breedList ->
+                /* Display success view */
+                log.v { "List submitted to adapter" }
+                adapter.submitList(breedList)
+            },
+            { exception ->
+                /* Display error view */
+                log.e { "Error displayed: $exception" }
+                Snackbar.make(
+                    binding.breedList,
+                    exception.toString(),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            },
+            {
+                /* Display empty response view */
+            }
+        )
 
-        viewModel.errorLiveData.observe(this) { errorMessage ->
-            log.e { "Error displayed: $errorMessage" }
-            Snackbar.make(binding.breedList, errorMessage, Snackbar.LENGTH_SHORT).show()
-        }
 
         binding.breedList.adapter = adapter
         binding.breedList.layoutManager = LinearLayoutManager(this)
 
-        viewModel.getBreedsFromNetwork()
+        viewModel.getBreeds()
+    }
+
+    private fun collectDataStateFlow(
+        onLoading: () -> Unit,
+        onSuccess: (List<Breed>) -> Unit,
+        onError: (Exception) -> Unit,
+        onEmpty: () -> Unit,
+    ) {
+        lifecycleScope.launch {
+            viewModel.breedStateFlow.collect {
+                    dataState ->
+                when(dataState) {
+                    is DataState.Success -> {
+                        onSuccess(dataState.data.allItems)
+                    }
+                    is DataState.Error -> {
+                        onError(dataState.exception)
+                    }
+                    DataState.Empty -> {
+                        onEmpty()
+                    }
+                    DataState.Loading -> {
+                        onLoading()
+                    }
+                }
+
+            }
+        }
     }
 }

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : AppCompatActivity(), KoinComponent {
     private fun collectDataStateFlow(
         onLoading: () -> Unit,
         onSuccess: (List<Breed>) -> Unit,
-        onError: (Exception) -> Unit,
+        onError: (String) -> Unit,
         onEmpty: () -> Unit,
     ) {
         lifecycleScope.launch {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -23,6 +23,7 @@ object Versions {
     val stately = "1.1.1"
     val serialization = "1.0.1"
     val kotlinxDateTime = "0.1.1"
+    val turbine = "0.3.0"
 
     object AndroidX {
         val appcompat = "1.2.0"
@@ -50,6 +51,7 @@ object Deps {
     val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
     val stately = "co.touchlab:stately-common:${Versions.stately}"
     val kotlinxDateTime = "org.jetbrains.kotlinx:kotlinx-datetime:${Versions.kotlinxDateTime}"
+    val turbine = "app.cash.turbine:turbine:${Versions.turbine}"
 
     object AndroidX {
         val appcompat = "androidx.appcompat:appcompat:${Versions.AndroidX.appcompat}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -56,6 +56,7 @@ object Deps {
         val core_ktx = "androidx.core:core-ktx:${Versions.AndroidX.core}"
         val constraintlayout = "androidx.constraintlayout:constraintlayout:${Versions.AndroidX.constraintlayout}"
         val recyclerView = "androidx.recyclerview:recyclerview:${Versions.AndroidX.recyclerview}"
+        val lifecycle_runtime = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.AndroidX.lifecycle}"
         val lifecycle_viewmodel = "androidx.lifecycle:lifecycle-viewmodel:${Versions.AndroidX.lifecycle}"
         val lifecycle_viewmodel_extensions = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.AndroidX.lifecycle}"
         val lifecycle_livedata = "androidx.lifecycle:lifecycle-livedata:${Versions.AndroidX.lifecycle}"

--- a/ios/KaMPKitiOS/ViewController.swift
+++ b/ios/KaMPKitiOS/ViewController.swift
@@ -17,19 +17,10 @@ class BreedsViewController: UIViewController {
     let log = koin.get(objCClass: Kermit.self, parameter: "ViewController") as! Kermit
 
     lazy var adapter: NativeViewModel = NativeViewModel(
-        onLoading: {
-            // Show a loading spinner
-        },
-        onSuccess: { [weak self] summary in
-            self?.viewUpdateSuccess(for: summary)
-        },
-        onError: {
-            [weak self] error in
-            self?.errorUpdate(for: (error as! Error).localizedDescription)
-        },
-        onEmpty: {
-            // Show "No doggos found!" message
-        }
+        onLoading: { /* Show a loading spinner */ },
+        onSuccess: { [weak self] summary in self?.viewUpdateSuccess(for: summary) },
+        onError: { [weak self] error in self?.errorUpdate(for: error) },
+        onEmpty: { /* Show "No doggos found!" message */}
     )
     
     // MARK: View Lifecycle

--- a/ios/KaMPKitiOS/ViewController.swift
+++ b/ios/KaMPKitiOS/ViewController.swift
@@ -19,8 +19,6 @@ class BreedsViewController: UIViewController {
     lazy var adapter: NativeViewModel = NativeViewModel(
         viewUpdate: { [weak self] summary in
             self?.viewUpdate(for: summary)
-        }, errorUpdate: { [weak self] errorMessage in
-            self?.errorUpdate(for: errorMessage)
         }
     )
     
@@ -29,9 +27,9 @@ class BreedsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         breedTableView.dataSource = self
-        
+
         //We check for stalk data in this method
-        adapter.getBreedsFromNetwork()
+        adapter.getBreeds()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -41,11 +39,22 @@ class BreedsViewController: UIViewController {
     
     // MARK: BreedModel Closures
     
-    private func viewUpdate(for summary: ItemDataSummary) {
-        log.d(withMessage: {"View updating with \(summary.allItems.count) breeds"})
-        data = summary.allItems
-        breedTableView.reloadData()
+private func viewUpdate(for summaryState: DataState<ItemDataSummary>) {
+    let summaryStateEnum: DataStateEnum<ItemDataSummary> = DataStateToEnum(summaryState)
+    switch(summaryStateEnum) {
+        case .Success(let successData):
+            log.d(withMessage: {"View updating with \(successData.allItems.count) breeds"})
+            data = successData.allItems
+            breedTableView.reloadData()
+        case .Error(let error):
+            errorUpdate(for: error.localizedDescription)
+        case .Empty: break
+            // Show "No doggos found!" message
+        case .Loading: break
+        default: break
+            // Show a loading spinner
     }
+}
     
     private func errorUpdate(for errorMessage: String) {
         log.e(withMessage: {"Displaying error: \(errorMessage)"})
@@ -79,3 +88,31 @@ extension BreedsViewController: BreedCellDelegate {
         adapter.updateBreedFavorite(breed: breed)
     }
 }
+
+enum DataStateEnum<T> {
+    case Success(_ data: T)
+    case Error(_ error: Error)
+    case Loading
+    case Empty
+}
+
+func DataStateToEnum<T>(_ dataState: DataState<T>) -> DataStateEnum<T> {
+    switch dataState {
+    case is DataStateSuccess<T>:
+        let mDataState = (dataState as! DataStateSuccess)
+        return DataStateEnum.Success(mDataState.data!)
+        
+    case is DataStateError:
+        let mDataState = (dataState as! DataStateError)
+        return DataStateEnum.Error(mDataState.exception as! Error)
+    
+    case is DataStateLoading:
+        return DataStateEnum.Loading
+    
+    case is DataStateEmpty:
+        fallthrough
+    default:
+        return DataStateEnum.Empty
+    }
+}
+

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
         implementation(Deps.koinTest)
         // Karmok is an experimental library which helps with mocking interfaces
         implementation(Deps.karmok)
+        implementation(Deps.turbine)
     }
 
     sourceSets["androidMain"].dependencies {

--- a/shared/src/androidTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
+++ b/shared/src/androidTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import co.touchlab.kampkit.db.KaMPKitDb
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
+
 internal actual fun testDbConnection(): SqlDriver {
     val app = ApplicationProvider.getApplicationContext<Application>()
     return AndroidSqliteDriver(KaMPKitDb.Schema, app, "kampkitdb")

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -15,7 +15,8 @@ import io.ktor.http.takeFrom
 
 class DogApiImpl(log: Kermit) : KtorApi {
 
-    // If this is a constructor property, then it gets captured inside HttpClient config and freezes this whole class
+    // If this is a constructor property, then it gets captured
+    // inside HttpClient config and freezes this whole class.
     @Suppress("CanBePrimaryConstructorProperty")
     private val log = log
 

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -87,7 +87,7 @@ class BreedModel : KoinComponent {
         return try {
             val breedResult = ktorApi.getJsonFromApi()
             log.v { "Breed network result: ${breedResult.status}" }
-            val breedList = breedResult.message.keys.toList()
+            val breedList = breedResult.message.keys.sorted().toList()
             log.v { "Fetched ${breedList.size} breeds from network" }
             settings.putLong(DB_TIMESTAMP_KEY, currentTimeMS)
             if (breedList.isEmpty()) {

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -6,6 +6,10 @@ import co.touchlab.kampkit.ktor.KtorApi
 import co.touchlab.kermit.Kermit
 import co.touchlab.stately.ensureNeverFrozen
 import com.russhwolf.settings.Settings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.datetime.Clock
 import org.koin.core.KoinComponent
@@ -26,40 +30,80 @@ class BreedModel : KoinComponent {
         ensureNeverFrozen()
     }
 
-    fun selectAllBreeds() =
+    fun getBreeds(): Flow<DataState<ItemDataSummary>> = flow {
+        emit(DataState.Loading)
+        val currentTimeMS = Clock.System.now().toEpochMilliseconds()
+        val stale = isBreedListStale(currentTimeMS)
+        val networkBreedDataState: DataState<ItemDataSummary>
+        if (stale) {
+            networkBreedDataState = getBreedsFromNetwork(currentTimeMS)
+            when (networkBreedDataState) {
+                DataState.Empty -> {
+                    // Pass the empty response along
+                    emit(networkBreedDataState)
+                }
+                is DataState.Success -> {
+                    dbHelper.insertBreeds(networkBreedDataState.data.allItems.map { it.name })
+                }
+                is DataState.Error -> {
+                    // Pass the error along
+                    emit(networkBreedDataState)
+                }
+
+                DataState.Loading -> {
+                    // Won't ever happen
+                }
+            }
+        }
+
+        getBreedsFromCache().conflate().collect {
+            emit(it)
+        }
+    }
+
+    fun getBreedsFromCache(): Flow<DataState<ItemDataSummary>> =
         dbHelper.selectAllItems()
             .map { itemList ->
                 log.v { "Select all query dirtied" }
-                ItemDataSummary(
-                    itemList.maxByOrNull { it.name.length },
-                    itemList
-                )
+                    DataState.Success(ItemDataSummary(
+                        itemList.maxByOrNull { it.name.length },
+                        itemList))
             }
 
-    suspend fun getBreedsFromNetwork(): String? {
-        fun isBreedListStale(currentTimeMS: Long): Boolean {
-            val lastDownloadTimeMS = settings.getLong(DB_TIMESTAMP_KEY, 0)
-            val oneHourMS = 60 * 60 * 1000
-            return (lastDownloadTimeMS + oneHourMS < currentTimeMS)
-        }
 
-        val currentTimeMS = Clock.System.now().toEpochMilliseconds()
-        if (isBreedListStale(currentTimeMS)) {
-            try {
-                val breedResult = ktorApi.getJsonFromApi()
-                log.v { "Breed network result: ${breedResult.status}" }
-                val breedList = breedResult.message.keys.toList()
-                log.v { "Fetched ${breedList.size} breeds from network" }
-                dbHelper.insertBreeds(breedList)
-                settings.putLong(DB_TIMESTAMP_KEY, currentTimeMS)
-            } catch (e: Exception) {
-                log.e(e) { "Error downloading breed list" }
-                return "Unable to download breed list"
-            }
-        } else {
+    private fun isBreedListStale(currentTimeMS: Long): Boolean {
+        val lastDownloadTimeMS = settings.getLong(DB_TIMESTAMP_KEY, 0)
+        val oneHourMS = 60 * 60 * 1000
+        val stale = lastDownloadTimeMS + oneHourMS < currentTimeMS
+        if (!stale) {
             log.i { "Breeds not fetched from network. Recently updated" }
         }
-        return null
+        return stale
+    }
+
+    suspend fun getBreedsFromNetwork(currentTimeMS: Long): DataState<ItemDataSummary> {
+
+        return try {
+            val breedResult = ktorApi.getJsonFromApi()
+            log.v { "Breed network result: ${breedResult.status}" }
+            val breedList = breedResult.message.keys.toList()
+            log.v { "Fetched ${breedList.size} breeds from network" }
+            settings.putLong(DB_TIMESTAMP_KEY, currentTimeMS)
+            if (breedList.isEmpty()) {
+                DataState.Empty
+            } else {
+                DataState.Success(
+                    ItemDataSummary(
+                        null,
+                        breedList.map { Breed(0L, it, 0L) }
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            log.e(e) { "Error downloading breed list" }
+            DataState.Error(Exception("Unable to download breed list"))
+        }
+
     }
 
     suspend fun updateBreedFavorite(breed: Breed) {

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -101,7 +101,7 @@ class BreedModel : KoinComponent {
             }
         } catch (e: Exception) {
             log.e(e) { "Error downloading breed list" }
-            DataState.Error(Exception("Unable to download breed list"))
+            DataState.Error("Unable to download breed list")
         }
 
     }

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedModel.kt
@@ -65,11 +65,13 @@ class BreedModel : KoinComponent {
         dbHelper.selectAllItems()
             .map { itemList ->
                 log.v { "Select all query dirtied" }
-                    DataState.Success(ItemDataSummary(
+                DataState.Success(
+                    ItemDataSummary(
                         itemList.maxByOrNull { it.name.length },
-                        itemList))
+                        itemList
+                    )
+                )
             }
-
 
     private fun isBreedListStale(currentTimeMS: Long): Boolean {
         val lastDownloadTimeMS = settings.getLong(DB_TIMESTAMP_KEY, 0)
@@ -82,7 +84,6 @@ class BreedModel : KoinComponent {
     }
 
     suspend fun getBreedsFromNetwork(currentTimeMS: Long): DataState<ItemDataSummary> {
-
         return try {
             val breedResult = ktorApi.getJsonFromApi()
             log.v { "Breed network result: ${breedResult.status}" }
@@ -103,7 +104,6 @@ class BreedModel : KoinComponent {
             log.e(e) { "Error downloading breed list" }
             DataState.Error("Unable to download breed list")
         }
-
     }
 
     suspend fun updateBreedFavorite(breed: Breed) {

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -1,0 +1,8 @@
+package co.touchlab.kampkit.models
+
+sealed class DataState<out T> {
+    data class Success<T>(val data: T): DataState<T>()
+    data class Error(val exception: Exception): DataState<Nothing>()
+    object Empty: DataState<Nothing>()
+    object Loading: DataState<Nothing>()
+}

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -2,7 +2,7 @@ package co.touchlab.kampkit.models
 
 sealed class DataState<out T> {
     data class Success<T>(val data: T): DataState<T>()
-    data class Error(val exception: Exception): DataState<Nothing>()
+    data class Error(val exception: String): DataState<Nothing>()
     object Empty: DataState<Nothing>()
     object Loading: DataState<Nothing>()
 }

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -1,8 +1,8 @@
 package co.touchlab.kampkit.models
 
 sealed class DataState<out T> {
-    data class Success<T>(val data: T): DataState<T>()
-    data class Error(val exception: String): DataState<Nothing>()
-    object Empty: DataState<Nothing>()
-    object Loading: DataState<Nothing>()
+    data class Success<T>(val data: T) : DataState<T>()
+    data class Error(val exception: String) : DataState<Nothing>()
+    object Empty : DataState<Nothing>()
+    object Loading : DataState<Nothing>()
 }

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -59,6 +59,7 @@ class BreedModelTest : BaseTest() {
     @Test
     fun updateFavoriteTest() = runTest {
         ktorApi.mock.getJsonFromApi.returns(ktorApi.successResult())
+        dbHelper.deleteAll()
         val appenzeller = Breed(1, "appenzeller", 0L)
         val australianNoLike = Breed(2, "australian", 0L)
         val australianLike = Breed(2, "australian", 1L)

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -33,7 +33,7 @@ class BreedModelTest : BaseTest() {
         appStart(dbHelper, settings, ktorApi, kermit)
         dbHelper.deleteAll()
         model = BreedModel()
-        model.selectAllBreeds().first()
+        model.getBreedsFromCache().first()
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -1,7 +1,11 @@
 package co.touchlab.kampkit
 
+import app.cash.turbine.test
+import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.mock.KtorApiMock
 import co.touchlab.kampkit.models.BreedModel
+import co.touchlab.kampkit.models.DataState
+import co.touchlab.kampkit.models.ItemDataSummary
 import co.touchlab.kermit.Kermit
 import com.russhwolf.settings.MockSettings
 import kotlinx.coroutines.Dispatchers
@@ -11,10 +15,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.ExperimentalTime
 
 class BreedModelTest : BaseTest() {
 
@@ -27,10 +30,6 @@ class BreedModelTest : BaseTest() {
     )
     private val settings = MockSettings()
     private val ktorApi = KtorApiMock()
-
-    companion object {
-        private const val oneHourMS: Long = (60 * 60 * 1000)
-    }
 
     @BeforeTest
     fun setup() = runTest {
@@ -46,28 +45,43 @@ class BreedModelTest : BaseTest() {
         settings.putLong(BreedModel.DB_TIMESTAMP_KEY, currentTimeMS)
         assertTrue(ktorApi.mock.getJsonFromApi.calledCount == 0)
 
-        assertNull(model.getBreedsFromNetwork(oneHourMS))
+        val expectedError = DataState.Error("Unable to download breed list")
+        val actualError = model.getBreedsFromNetwork(0L)
+
+        assertEquals(
+            expectedError,
+            actualError
+        )
         assertTrue(ktorApi.mock.getJsonFromApi.calledCount == 0)
     }
 
+    @ExperimentalTime
     @Test
     fun updateFavoriteTest() = runTest {
         ktorApi.mock.getJsonFromApi.returns(ktorApi.successResult())
-        assertNull(model.getBreedsFromNetwork(oneHourMS))
-        val breedOld = dbHelper.selectAllItems().first().first()
-        assertFalse(breedOld.isFavorited())
+        val appenzeller = Breed(1, "appenzeller", 0L)
+        val australianNoLike = Breed(2, "australian", 0L)
+        val australianLike = Breed(2, "australian", 1L)
 
-        model.updateBreedFavorite(breedOld)
+        val dataStateSuccessNoFavorite = DataState.Success(
+            ItemDataSummary(appenzeller, listOf(appenzeller, australianNoLike))
+        )
 
-        val breedNew = dbHelper.selectById(breedOld.id).first().first()
-        assertEquals(breedNew.id, breedOld.id)
-        assertTrue(breedNew.isFavorited())
+        val dataStateSuccessFavorite = DataState.Success(
+            ItemDataSummary(appenzeller, listOf(appenzeller, australianLike))
+        )
+
+        model.getBreeds().test {
+            assertEquals(DataState.Loading, expectItem())
+            assertEquals(dataStateSuccessNoFavorite, expectItem())
+            model.updateBreedFavorite(australianNoLike)
+            assertEquals(dataStateSuccessFavorite, expectItem())
+        }
     }
 
     @Test
     fun notifyErrorOnException() = runTest {
         ktorApi.mock.getJsonFromApi.throwOnCall(RuntimeException())
-
         assertNotNull(model.getBreedsFromNetwork(0L))
     }
 

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -28,6 +28,10 @@ class BreedModelTest : BaseTest() {
     private val settings = MockSettings()
     private val ktorApi = KtorApiMock()
 
+    companion object {
+        private const val oneHourMS: Long = (60 * 60 * 1000)
+    }
+
     @BeforeTest
     fun setup() = runTest {
         appStart(dbHelper, settings, ktorApi, kermit)
@@ -42,14 +46,14 @@ class BreedModelTest : BaseTest() {
         settings.putLong(BreedModel.DB_TIMESTAMP_KEY, currentTimeMS)
         assertTrue(ktorApi.mock.getJsonFromApi.calledCount == 0)
 
-        assertNull(model.getBreedsFromNetwork())
+        assertNull(model.getBreedsFromNetwork(oneHourMS))
         assertTrue(ktorApi.mock.getJsonFromApi.calledCount == 0)
     }
 
     @Test
     fun updateFavoriteTest() = runTest {
         ktorApi.mock.getJsonFromApi.returns(ktorApi.successResult())
-        assertNull(model.getBreedsFromNetwork())
+        assertNull(model.getBreedsFromNetwork(oneHourMS))
         val breedOld = dbHelper.selectAllItems().first().first()
         assertFalse(breedOld.isFavorited())
 
@@ -64,7 +68,7 @@ class BreedModelTest : BaseTest() {
     fun notifyErrorOnException() = runTest {
         ktorApi.mock.getJsonFromApi.throwOnCall(RuntimeException())
 
-        assertNotNull(model.getBreedsFromNetwork())
+        assertNotNull(model.getBreedsFromNetwork(0L))
     }
 
     @AfterTest

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/SqlDelightTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/SqlDelightTest.kt
@@ -2,7 +2,6 @@ package co.touchlab.kampkit
 
 import co.touchlab.kermit.Kermit
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.first
 import kotlin.test.BeforeTest
 import kotlin.test.Test

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/NativeViewModel.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/NativeViewModel.kt
@@ -16,7 +16,7 @@ import org.koin.core.parameter.parametersOf
 class NativeViewModel(
     private val onLoading: () -> Unit,
     private val onSuccess: (ItemDataSummary) -> Unit,
-    private val onError: (Exception) -> Unit,
+    private val onError: (String) -> Unit,
     private val onEmpty: () -> Unit
 ) : KoinComponent {
 

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/NativeViewModel.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/NativeViewModel.kt
@@ -2,6 +2,7 @@ package co.touchlab.kampkit
 
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.models.BreedModel
+import co.touchlab.kampkit.models.DataState
 import co.touchlab.kampkit.models.ItemDataSummary
 import co.touchlab.kermit.Kermit
 import co.touchlab.stately.ensureNeverFrozen
@@ -13,8 +14,7 @@ import org.koin.core.inject
 import org.koin.core.parameter.parametersOf
 
 class NativeViewModel(
-    private val viewUpdate: (ItemDataSummary) -> Unit,
-    private val errorUpdate: (String) -> Unit
+    private val viewUpdate: (DataState<ItemDataSummary>) -> Unit
 ) : KoinComponent {
 
     private val log: Kermit by inject { parametersOf("BreedModel") }
@@ -24,13 +24,13 @@ class NativeViewModel(
     init {
         ensureNeverFrozen()
         breedModel = BreedModel()
-        observeBreeds()
+        getBreeds()
     }
 
-    private fun observeBreeds() {
+    fun getBreeds() {
         scope.launch {
             log.v { "Observe Breeds" }
-            breedModel.selectAllBreeds()
+            breedModel.getBreeds()
                 .collect { summary ->
                     log.v { "Collecting Things" }
                     viewUpdate(summary)
@@ -38,13 +38,13 @@ class NativeViewModel(
         }
     }
 
-    fun getBreedsFromNetwork() {
+/*    fun getBreedsFromNetwork() {
         scope.launch {
             breedModel.getBreedsFromNetwork()?.let { errorString ->
                 errorUpdate(errorString)
             }
         }
-    }
+    }*/
 
     fun updateBreedFavorite(breed: Breed) {
         scope.launch {


### PR DESCRIPTION
[Summary]
MVI helps maintain a single source of truth for the state of the view
overall (error, loading, success, empty).

StateFlow obviates LiveData with more capabilities along with
multiplatform support, unlike LiveData.

[Fix]
Add a DataState sealed class to model the view state, add Android lifecycle-ktx to collect the StateFlow in the MainActivity with lifecycleScope. Transform DataState from a sealed class in Kotlin shared to an enum in Swift.

[Testing]
- manual testing on iOS and Android

https://github.com/touchlab/KaMPKit/issues/161