### PR TITLE
[Issue-0000] DataState cleanup

### DIFF
--- a/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/BreedViewModel.kt
@@ -24,7 +24,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
     private val scope = viewModelScope
     private val breedModel: BreedModel = BreedModel()
     private val _breedStateFlow: MutableStateFlow<DataState<ItemDataSummary>> = MutableStateFlow(
-        DataState(loading = true)
+        DataState.Loading
     )
 
     val breedStateFlow: StateFlow<DataState<ItemDataSummary>> = _breedStateFlow
@@ -42,7 +42,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
                 breedModel.getBreedsFromCache()
             ).flattenMerge().collect { dataState ->
                 if (dataState.loading) {
-                    val temp = _breedStateFlow.value.copy(loading = true)
+                    val temp = _breedStateFlow.value.copy(isLoading = true)
                     _breedStateFlow.value = temp
                 } else {
                     _breedStateFlow.value = dataState
@@ -56,7 +56,7 @@ class BreedViewModel : ViewModel(), KoinComponent {
             log.v { "refreshBreeds" }
             breedModel.refreshBreedsIfStale(forced).collect { dataState ->
                 if (dataState.loading) {
-                    val temp = _breedStateFlow.value.copy(loading = true)
+                    val temp = _breedStateFlow.value.copy(isLoading = true)
                     _breedStateFlow.value = temp
                 } else {
                     _breedStateFlow.value = dataState

--- a/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import co.touchlab.kampkit.android.ui.MainScreen
 import co.touchlab.kampkit.android.ui.theme.KaMPKitTheme
+import co.touchlab.kampkit.models.DataState
 import co.touchlab.kermit.Kermit
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.component.KoinComponent
@@ -23,7 +24,7 @@ class MainActivity : ComponentActivity(), KoinComponent {
                 MainScreen(viewModel, log)
             }
         }
-        if (viewModel.breedStateFlow.value.data == null) {
+        if (viewModel.breedStateFlow.value !is DataState.Success) {
             viewModel.refreshBreeds()
         }
     }

--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -76,22 +76,25 @@ fun MainScreenContent(
             state = rememberSwipeRefreshState(isRefreshing = dogsState.loading),
             onRefresh = onRefresh
         ) {
-            if (dogsState.empty) {
-                Empty()
-            }
-            val data = dogsState.data
-            if (data != null) {
-                LaunchedEffect(data) {
-                    onSuccess(data)
+            when (dogsState) {
+                is DataState.Empty -> {
+                    Empty()
                 }
-                Success(successData = data, favoriteBreed = onFavorite)
-            }
-            val exception = dogsState.exception
-            if (exception != null) {
-                LaunchedEffect(exception) {
-                    onError(exception)
+                is DataState.Error -> {
+                    LaunchedEffect(dogsState.exception) {
+                        onError(dogsState.exception)
+                    }
+                    Error(dogsState.exception)
                 }
-                Error(exception)
+                DataState.Loading -> {
+                    // Taken care of in SwipeRefresh above
+                }
+                is DataState.Success -> {
+                    LaunchedEffect(dogsState.data) {
+                        onSuccess(dogsState.data)
+                    }
+                    Success(successData = dogsState.data, favoriteBreed = onFavorite)
+                }
             }
         }
     }
@@ -182,7 +185,7 @@ fun FavoriteIcon(breed: Breed) {
 @Composable
 fun MainScreenContentPreview_Success() {
     MainScreenContent(
-        dogsState = DataState(
+        dogsState = DataState.Success(
             data = ItemDataSummary(
                 longestItem = null,
                 allItems = listOf(

--- a/ios/KaMPKitiOS/BreedListScreen.swift
+++ b/ios/KaMPKitiOS/BreedListScreen.swift
@@ -24,18 +24,28 @@ class ObservableBreedModel: ObservableObject {
     var error: String? = nil
     
     func activate() {
-        viewModel = NativeViewModel { [weak self] dataState in
-            self?.loading = dataState.loading
-            self?.breeds = dataState.data?.allItems
-            self?.error = dataState.exception
-            
-            if let breeds = dataState.data?.allItems {
-                log.d(withMessage: {"View updating with \(breeds.count) breeds"})
+        viewModel = NativeViewModel(
+            onSuccess: { [weak self] success in
+                self?.loading = success.loading
+                let items = success.data?.allItems
+                let count = items?.count ?? 0
+                self?.breeds = items
+                log.d(withMessage: {"View updating with \(count) breeds"})
+                self?.error = nil
+            },
+            onError: { [weak self] error in
+                self?.loading = error.loading
+                self?.error = error.exception
+                log.e(withMessage: {"Displaying error: \(error.exception)"})
+            },
+            onEmpty: { [weak self] empty in
+                self?.loading = empty.loading
+                self?.error = nil
+            },
+            onLoading: { [weak self] in
+                self?.loading = true
             }
-            if let errorMessage = dataState.exception {
-                log.e(withMessage: {"Displaying error: \(errorMessage)"})
-            }
-        }
+        )
     }
     
     func deactivate() {
@@ -94,6 +104,9 @@ struct BreedListContent : View{
                 if let error = error {
                     Text(error)
                         .foregroundColor(.red)
+                }
+                if (breeds == nil || error == nil) {
+                    Spacer()
                 }
                 Button("Refresh") {
                     refresh()

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -35,7 +35,7 @@ class DogApiImpl(log: Kermit) : KtorApi {
             level = LogLevel.INFO
         }
         install(HttpTimeout) {
-            val timeout = 30000L
+            val timeout = 3000L
             connectTimeoutMillis = timeout
             requestTimeoutMillis = timeout
             socketTimeoutMillis = timeout

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -1,8 +1,24 @@
 package co.touchlab.kampkit.models
 
-data class DataState<out T>(
-    val data: T? = null,
-    val exception: String? = null,
-    val empty: Boolean = false,
-    val loading: Boolean = false
-)
+sealed class DataState<out T>(open val loading: Boolean) {
+    class Success<T>(val data: T, override val loading: Boolean = false) : DataState<T>(loading) {
+        override fun copy(isLoading: Boolean): DataState<T> = Success(data, isLoading)
+        override fun equals(other: Any?) = other is Success<*> && other.data == data && other.loading == loading
+    }
+
+    class Error(val exception: String, override val loading: Boolean = false) : DataState<Nothing>(loading) {
+        override fun copy(isLoading: Boolean): DataState<Nothing> = Error(exception, isLoading)
+        override fun equals(other: Any?) = other is Error && other.exception == exception && other.loading == loading
+    }
+
+    class Empty(override val loading: Boolean = false) : DataState<Nothing>(loading) {
+        override fun copy(isLoading: Boolean) = this
+        override fun equals(other: Any?) = other is Empty && other.loading == loading
+    }
+
+    object Loading : DataState<Nothing>(true) {
+        override fun copy(isLoading: Boolean): DataState<Nothing> = this
+    }
+
+    abstract fun copy(isLoading: Boolean): DataState<T>
+}

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -42,10 +42,10 @@ class BreedModelTest : BaseTest() {
         private val appenzeller = Breed(1, "appenzeller", 0L)
         private val australianNoLike = Breed(2, "australian", 0L)
         private val australianLike = Breed(2, "australian", 1L)
-        val dataStateSuccessNoFavorite = DataState(
+        val dataStateSuccessNoFavorite = DataState.Success(
             data = ItemDataSummary(appenzeller, listOf(appenzeller, australianNoLike))
         )
-        private val dataStateSuccessFavorite = DataState(
+        private val dataStateSuccessFavorite = DataState.Success(
             data = ItemDataSummary(appenzeller, listOf(appenzeller, australianLike))
         )
     }
@@ -61,7 +61,7 @@ class BreedModelTest : BaseTest() {
         settings.putLong(BreedModel.DB_TIMESTAMP_KEY, currentTimeMS)
         assertTrue(ktorApi.calledCount == 0)
 
-        val expectedError = DataState<ItemDataSummary>(exception = "Unable to download breed list")
+        val expectedError = DataState.Error(exception = "Unable to download breed list")
         val actualError = model.getBreedsFromNetwork(0L)
 
         assertEquals(
@@ -79,7 +79,7 @@ class BreedModelTest : BaseTest() {
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
             .flattenMerge().test {
                 // Loading
-                assertEquals(DataState(loading = true), expectItem())
+                assertEquals(DataState.Loading, expectItem())
                 // No Favorites
                 assertEquals(dataStateSuccessNoFavorite, expectItem())
                 // Add 1 favorite breed
@@ -98,7 +98,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState(loading = true), expectItem())
+                    assertEquals(DataState.Loading, expectItem())
                     assertEquals(dataStateSuccessNoFavorite, expectItem())
                     // "Like" the Australian breed
                     model.updateBreedFavorite(australianNoLike)
@@ -114,7 +114,7 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(true), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState(loading = true), expectItem())
+                    assertEquals(DataState.Loading, expectItem())
                     // Get the new result with the Australian breed liked
                     assertEquals(dataStateSuccessFavorite, expectItem())
                     cancel()
@@ -129,10 +129,10 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(successResult)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState(loading = true), expectItem())
+                assertEquals(DataState.Loading, expectItem())
                 val oldBreeds = expectItem()
+                assertTrue(oldBreeds is DataState.Success)
                 val data = oldBreeds.data
-                assertTrue(data != null)
                 assertEquals(
                     ktorApi.successResult().message.keys.size,
                     data.allItems.size
@@ -146,11 +146,14 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(resultWithExtraBreed)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState(loading = true), expectItem())
+                assertEquals(DataState.Loading, expectItem())
                 val updated = expectItem()
+                assertTrue(updated is DataState.Success)
                 val data = updated.data
-                assertTrue(data != null)
-                assertEquals(resultWithExtraBreed.message.keys.size, data.allItems.size)
+                assertEquals(
+                    resultWithExtraBreed.message.keys.size,
+                    data.allItems.size
+                )
             }
     }
 


### PR DESCRIPTION
## Summary
Was inspired by this: https://twitter.com/JorgeCastilloPr/status/1428731347888230402
There is another way to handle state than the previous 2 ways, and I
wanted the best aspects of both of them:
- mutually exclusive states
- No nullability
- Easy reasoning at the View level

## Fix
Make `DataState` a sealed class, but give each a `loading` Boolean

## Testing
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing


