### PR TITLE
Fix an issue that caused tests to crash when `launch` in `runTest` throws

### DIFF
--- a/shared/src/androidTest/kotlin/co/touchlab/kampkit/BaseTest.kt
+++ b/shared/src/androidTest/kotlin/co/touchlab/kampkit/BaseTest.kt
@@ -2,6 +2,7 @@ package co.touchlab.kampkit
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -12,6 +13,6 @@ actual abstract class BaseTest {
     var coroutineTestRule = CoroutineTestRule()
 
     actual fun <T> runTest(block: suspend CoroutineScope.() -> T) {
-        runBlocking { block() }
+        runBlocking { coroutineScope(block) }
     }
 }

--- a/shared/src/iosTest/kotlin/co/touchlab/kampkit/BaseTest.kt
+++ b/shared/src/iosTest/kotlin/co/touchlab/kampkit/BaseTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import platform.CoreFoundation.CFRunLoopGetCurrent
 import platform.CoreFoundation.CFRunLoopRun
@@ -15,7 +16,7 @@ actual abstract class BaseTest {
         var error: Throwable? = null
         GlobalScope.launch(Dispatchers.Main) {
             try {
-                block()
+                coroutineScope(block)
             } catch (t: Throwable) {
                 error = t
             } finally {


### PR DESCRIPTION

<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
No issues.

## Summary
<!--- Copy summary from issue link or write a shortened description of it -->
There is a problem that if you call `launch` inside of `runTest`, `runTest` will leave the scope without waiting for `launch` to complete.
In particular, on iOS, this can cause unexpected crashes since you will `launch` inside a `GlobalScope`.
By wrapping it with `coroutineScope`, the `runTest` will wait for the `launch`.

```kotlin
// This test case succeeds, but the test itself crashes.
fun testA() = runTest {
    launch {
        delay(100)
        throw SomeException()
    }
}
```

## Fix
<!-- What did you do to fix the issue? -->
Wraps `runTest`'s `block` with `coroutineScope`.

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`

<!-- If you made changes to the UI, please show us what it looks like now. -->
### **Screenshot / Video of App working with the Changes**
No UI changes.