### PR TITLE
Bump dependencies and enable HMPP

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ android.useAndroidX=true
 kotlin.code.style=official
 # Tell the KMM plugin where the iOS project lives
 xcodeproj=./ios
+# HMPP Flags
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,14 +5,14 @@ targetSdk = "31"
 compileSdk = "31"
 
 # Dependencies
-compose = "1.0.3"
-coroutines-native = "1.5.0-native-mt"
-multiplatformSettings = "0.7.7"
-koin = "3.0.2"
-kotlin = "1.5.30"
-ktor = "1.6.0"
-lifecycle = "2.4.0-alpha02"
-sqlDelight = "1.5.0"
+compose = "1.0.4"
+coroutines-native = "1.5.2-native-mt"
+multiplatformSettings = "0.8.1"
+koin = "3.1.2"
+kotlin = "1.5.31"
+ktor = "1.6.4"
+lifecycle = "2.4.0-rc01"
+sqlDelight = "1.5.2"
 
 [libraries]
 
@@ -20,22 +20,22 @@ android-desugaring = { module = "com.android.tools:desugar_jdk_libs", version = 
 androidx-core = { module = "androidx.core:core-ktx", version = "1.6.0" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
-androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.2" }
+androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.1.3" }
 
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.0" }
+compose-activity = { module = "androidx.activity:activity-compose", version = "1.3.1" }
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines-native" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-native" }
 
-google-accompanist-swipeRefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version = "0.13.0" }
+google-accompanist-swipeRefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version = "0.20.0" }
 
-gradlePlugin-android = { module = "com.android.tools.build:gradle", version = "7.0.1" }
+gradlePlugin-android = { module = "com.android.tools.build:gradle", version = "7.0.3" }
 gradlePlugin-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
-gradlePlugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "10.0.0" }
+gradlePlugin-ktlint = { module = "org.jlleitschuh.gradle:ktlint-gradle", version = "10.2.0" }
 gradlePlugin-sqlDelight = { module = "com.squareup.sqldelight:gradle-plugin", version.ref = "sqlDelight" }
 
 junit = { module = "junit:junit", version = "4.13.2" }
@@ -44,7 +44,7 @@ koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 
-kotlinx-dateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.2.1" }
+kotlinx-dateTime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.3.0" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-ios = { module = "io.ktor:ktor-client-ios", version.ref = "ktor" }
@@ -55,7 +55,7 @@ ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", vers
 multiplatformSettings-common = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 multiplatformSettings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatformSettings" }
 
-roboelectric = { module = "org.robolectric:robolectric", version = "4.5.1"}
+roboelectric = { module = "org.robolectric:robolectric", version = "4.6.1" }
 
 sqlDelight-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqlDelight-coroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
@@ -63,9 +63,9 @@ sqlDelight-native = { module = "com.squareup.sqldelight:native-driver", version.
 sqlDelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqlDelight" }
 
 touchlab-kermit = { module = "co.touchlab:kermit", version = "0.1.9" }
-touchlab-stately = { module = "co.touchlab:stately-common", version = "1.1.7" }
+touchlab-stately = { module = "co.touchlab:stately-common", version = "1.1.10" }
 
-turbine = { module = "app.cash.turbine:turbine", version = "0.5.2" }
+turbine = { module = "app.cash.turbine:turbine", version = "0.7.0" }
 
 [bundles]
 app-ui = [
@@ -96,3 +96,4 @@ shared-androidTest = [
     "coroutines-test",
     "roboelectric"
 ]
+

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     kotlin("multiplatform")
     kotlin("native.cocoapods")
@@ -37,13 +35,11 @@ android {
 
 kotlin {
     android()
-    // Revert to just ios() when gradle plugin can properly resolve it
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget = when {
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true -> ::iosArm64
-        System.getenv("NATIVE_ARCH")?.startsWith("arm") == true -> ::iosSimulatorArm64
-        else -> ::iosX64
-    }
-    iosTarget("ios") {}
+    ios()
+    // Don't add this until all dependencies support M1 targets
+    // iosSimulatorArm64()
+    // sourceSets["iosSimulatorArm64Main"].dependsOn(sourceSets["iosMain"])
+    // sourceSets["iosSimulatorArm64Test"].dependsOn(sourceSets["iosTest"])
 
     version = "1.1"
 

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedModelTest.kt
@@ -79,13 +79,13 @@ class BreedModelTest : BaseTest() {
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
             .flattenMerge().test {
                 // Loading
-                assertEquals(DataState(loading = true), expectItem())
+                assertEquals(DataState(loading = true), awaitItem())
                 // No Favorites
-                assertEquals(dataStateSuccessNoFavorite, expectItem())
+                assertEquals(dataStateSuccessNoFavorite, awaitItem())
                 // Add 1 favorite breed
                 model.updateBreedFavorite(australianNoLike)
                 // Get the new result with 1 breed favorited
-                assertEquals(dataStateSuccessFavorite, expectItem())
+                assertEquals(dataStateSuccessFavorite, awaitItem())
             }
     }
 
@@ -98,12 +98,12 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState(loading = true), expectItem())
-                    assertEquals(dataStateSuccessNoFavorite, expectItem())
+                    assertEquals(DataState(loading = true), awaitItem())
+                    assertEquals(dataStateSuccessNoFavorite, awaitItem())
                     // "Like" the Australian breed
                     model.updateBreedFavorite(australianNoLike)
                     // Get the new result with the Australian breed liked
-                    assertEquals(dataStateSuccessFavorite, expectItem())
+                    assertEquals(dataStateSuccessFavorite, awaitItem())
                     cancel()
                 }
         }
@@ -114,9 +114,9 @@ class BreedModelTest : BaseTest() {
             flowOf(model.refreshBreedsIfStale(true), model.getBreedsFromCache())
                 .flattenMerge().test {
                     // Loading
-                    assertEquals(DataState(loading = true), expectItem())
+                    assertEquals(DataState(loading = true), awaitItem())
                     // Get the new result with the Australian breed liked
-                    assertEquals(dataStateSuccessFavorite, expectItem())
+                    assertEquals(dataStateSuccessFavorite, awaitItem())
                     cancel()
                 }
         }
@@ -129,8 +129,8 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(successResult)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState(loading = true), expectItem())
-                val oldBreeds = expectItem()
+                assertEquals(DataState(loading = true), awaitItem())
+                val oldBreeds = awaitItem()
                 val data = oldBreeds.data
                 assertTrue(data != null)
                 assertEquals(
@@ -146,8 +146,8 @@ class BreedModelTest : BaseTest() {
         ktorApi.prepareResult(resultWithExtraBreed)
         flowOf(model.refreshBreedsIfStale(), model.getBreedsFromCache()).flattenMerge()
             .test(timeout = Duration.seconds(30)) {
-                assertEquals(DataState(loading = true), expectItem())
-                val updated = expectItem()
+                assertEquals(DataState(loading = true), awaitItem())
+                val updated = awaitItem()
                 val data = updated.data
                 assertTrue(data != null)
                 assertEquals(resultWithExtraBreed.message.keys.size, data.allItems.size)


### PR DESCRIPTION
## Summary
Bumps dependencies to latest versions, and enables HMPP. Note that until we update Kermit, that shows up as red in the IDE in `KoinIOS.kt`. All other dependencies are on HMPP-enabled versions and IDE inference seems to work fine in AS Arctic Fox as well as IDEA 2021.3 EAP.