### PR TITLE
Update dependencies and enable M1 support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,11 +8,11 @@ compileSdk = "31"
 compose = "1.0.4"
 coroutines-native = "1.5.2-native-mt"
 multiplatformSettings = "0.8.1"
-koin = "3.1.2"
+koin = "3.1.4"
 kotlin = "1.5.31"
-ktor = "1.6.4"
+ktor = "1.6.5"
 lifecycle = "2.4.0-rc01"
-sqlDelight = "1.5.2"
+sqlDelight = "1.5.3"
 
 [libraries]
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -36,10 +36,10 @@ android {
 kotlin {
     android()
     ios()
-    // Don't add this until all dependencies support M1 targets
-    // iosSimulatorArm64()
-    // sourceSets["iosSimulatorArm64Main"].dependsOn(sourceSets["iosMain"])
-    // sourceSets["iosSimulatorArm64Test"].dependsOn(sourceSets["iosTest"])
+    // Note: iosSimulatorArm64 target requires that all dependencies have M1 support
+    iosSimulatorArm64()
+    sourceSets["iosSimulatorArm64Main"].dependsOn(sourceSets["iosMain"])
+    sourceSets["iosSimulatorArm64Test"].dependsOn(sourceSets["iosTest"])
 
     version = "1.1"
 

--- a/shared/src/androidTest/kotlin/co/touchlab/kampkit/KoinTest.kt
+++ b/shared/src/androidTest/kotlin/co/touchlab/kampkit/KoinTest.kt
@@ -29,7 +29,7 @@ class KoinTest : BaseTest() {
                 single { {} }
             }
         ).checkModules {
-            create<Logger> { parametersOf("TestTag") }
+            withParameters<Logger> { parametersOf("TestTag") }
         }
     }
 

--- a/shared/src/iosTest/kotlin/co/touchlab/kampkit/KoinTest.kt
+++ b/shared/src/iosTest/kotlin/co/touchlab/kampkit/KoinTest.kt
@@ -16,7 +16,7 @@ class KoinTest : BaseTest() {
             appInfo = TestAppInfo,
             doOnStartup = { }
         ).checkModules {
-            create<Logger> { parametersOf("TestTag") }
+            withParameters<Logger> { parametersOf("TestTag") }
         }
     }
 


### PR DESCRIPTION
I have not tested this on an M1 machine yet so it'd be helpful if someone could give that a try.