### PR TITLE
Remove unnecessary suspend keyword from function returning a Flow

### DIFF
--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -34,7 +34,7 @@ class DatabaseHelper(
         }
     }
 
-    suspend fun selectById(id: Long): Flow<List<Breed>> =
+    fun selectById(id: Long): Flow<List<Breed>> =
         dbRef.tableQueries
             .selectById(id)
             .asFlow()


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
Issue: https://github.com/touchlab/KaMPKit/issues/232

## Summary
<!--- Copy summary from issue link or write a shortened description of it -->
Suspend functions should return when all of their work is done, returning a Flow shouldn't require the function to be suspending.
More context here: https://rules.sonarsource.com/kotlin/RSPEC-6309

## Fix
<!-- What did you do to fix the issue? -->
Removed the unnecessary `suspend` keyword

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- manual testing

<!-- If you made changes to the UI, please show us what it looks like now. -->