### PR TITLE
explicit kotlin test deps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,8 @@ touchlab-kermit = { module = "co.touchlab:kermit", version = "1.0.0" }
 touchlab-stately = { module = "co.touchlab:stately-common", version = "1.2.1" }
 
 turbine = { module = "app.cash.turbine:turbine", version = "0.7.0" }
+kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
+kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "kotlin" }
 
 [bundles]
 app-ui = [
@@ -92,6 +94,8 @@ gradlePlugins = [
 ]
 ktor-common = ["ktor-client-core", "ktor-client-logging", "ktor-client-serialization", "ktor-client-contentNegotiation"]
 shared-commonTest = [
+    "kotlin-test-common",
+    "kotlin-test-annotations-common",
     "multiplatformSettings-test",
     "koin-test",
     "turbine",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,8 +70,7 @@ touchlab-kermit = { module = "co.touchlab:kermit", version = "1.0.0" }
 touchlab-stately = { module = "co.touchlab:stately-common", version = "1.2.1" }
 
 turbine = { module = "app.cash.turbine:turbine", version = "0.7.0" }
-kotlin-test-common = { module = "org.jetbrains.kotlin:kotlin-test-common", version.ref = "kotlin" }
-kotlin-test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotations-common", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [bundles]
 app-ui = [
@@ -94,8 +93,7 @@ gradlePlugins = [
 ]
 ktor-common = ["ktor-client-core", "ktor-client-logging", "ktor-client-serialization", "ktor-client-contentNegotiation"]
 shared-commonTest = [
-    "kotlin-test-common",
-    "kotlin-test-annotations-common",
+    "kotlin-test",
     "multiplatformSettings-test",
     "koin-test",
     "turbine",


### PR DESCRIPTION
<!-- Add issue link -->
Issue: From slack thread https://kotlinlang.slack.com/archives/C3PQML5NU/p1645716586447599 

## Summary
We were getting kotlin test dependencies transitively through `koin-test` which can be confusing for people using part of the gradle set up. This just adds the deps explicitly wf

## Fix
<!-- What did you do to fix the issue? -->

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS 
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing
