### PR TITLE
Update Github Actions to use Ubuntu for Android

### DIFF
--- a/.github/workflows/KaMPKit-Android.yml
+++ b/.github/workflows/KaMPKit-Android.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/KaMPKit-Shared.yml
+++ b/.github/workflows/KaMPKit-Shared.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/KaMPKit-Shared.yml
+++ b/.github/workflows/KaMPKit-Shared.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Issue: https://github.com/touchlab/KaMPKit/issues/236

## Summary
Using macOS machines for building/testing Android modules is not a good bet for the following reasons:
- macOS machines, I found, are slower than their Ubuntu counterparts. 
- macOS machines [cost 10x](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) more in billing. Those who clone this repo privately will pay the price unnecessarily.
 
## Fix
Made Github Actions faster & less costly.

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS 
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing