### PR TITLE
Repository adjustments

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ multiplatformSettings-test = { module = "com.russhwolf:multiplatform-settings-te
 roboelectric = { module = "org.robolectric:robolectric", version = "4.7.3" }
 
 sqlDelight-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelight" }
+sqlDelight-jvm = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 sqlDelight-coroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
 sqlDelight-native = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqlDelight" }
 sqlDelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqlDelight" }
@@ -106,6 +107,7 @@ shared-commonTest = [
 shared-androidTest = [
     "androidx-test-junit",
     "coroutines-test",
-    "roboelectric"
+    "roboelectric",
+    "sqlDelight-jvm"
 ]
 

--- a/ios/KaMPKitiOS/BreedListScreen.swift
+++ b/ios/KaMPKitiOS/BreedListScreen.swift
@@ -29,15 +29,15 @@ class ObservableBreedModel: ObservableObject {
     func activate() {
         let viewModel = KotlinDependencies.shared.getBreedViewModel()
 
-        doPublish(viewModel.breeds) { [weak self] dataState in
-            self?.loading = dataState.loading
-            self?.breeds = dataState.data?.allItems
-            self?.error = dataState.exception
+        doPublish(viewModel.breeds) { [weak self] dogsState in
+            self?.loading = dogsState.isLoading
+            self?.breeds = dogsState.breeds
+            self?.error = dogsState.error
 
-            if let breeds = dataState.data?.allItems {
+            if let breeds = dogsState.breeds {
                 log.d(message: {"View updating with \(breeds.count) breeds"})
             }
-            if let errorMessage = dataState.exception {
+            if let errorMessage = dogsState.error {
                 log.e(message: {"Displaying error: \(errorMessage)"})
             }
         }.store(in: &cancellables)
@@ -123,7 +123,7 @@ struct BreedRowView: View {
                 Text(breed.name)
                     .padding(4.0)
                 Spacer()
-                Image(systemName: (breed.favorite == 0) ? "heart" : "heart.fill")
+                Image(systemName: (!breed.favorite) ? "heart" : "heart.fill")
                     .padding(4.0)
             }
         }
@@ -135,8 +135,8 @@ struct BreedListScreen_Previews: PreviewProvider {
         BreedListContent(
             loading: false,
             breeds: [
-                Breed(id: 0, name: "appenzeller", favorite: 0),
-                Breed(id: 1, name: "australian", favorite: 1)
+                Breed(id: 0, name: "appenzeller", favorite: false),
+                Breed(id: 1, name: "australian", favorite: true)
             ],
             error: nil,
             onBreedFavorite: { _ in },

--- a/shared/src/androidTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
+++ b/shared/src/androidTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
@@ -5,8 +5,16 @@ import androidx.test.core.app.ApplicationProvider
 import co.touchlab.kampkit.db.KaMPKitDb
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
+import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 
 internal actual fun testDbConnection(): SqlDriver {
-    val app = ApplicationProvider.getApplicationContext<Application>()
-    return AndroidSqliteDriver(KaMPKitDb.Schema, app, "kampkitdb")
+    // Try to use the android driver (which only works if we're on robolectric).
+    // Fall back to jdbc if that fails.
+    return try {
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        AndroidSqliteDriver(KaMPKitDb.Schema, app, "kampkitdb")
+    } catch (exception: IllegalStateException) {
+        JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            .also { KaMPKitDb.Schema.create(it) }
+    }
 }

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -25,11 +25,11 @@ class DatabaseHelper(
             .mapToList()
             .flowOn(backgroundDispatcher)
 
-    suspend fun insertBreeds(breeds: List<Breed>) {
+    suspend fun insertBreeds(breeds: List<String>) {
         log.d { "Inserting ${breeds.size} breeds into database" }
         dbRef.transactionWithContext(backgroundDispatcher) {
             breeds.forEach { breed ->
-                dbRef.tableQueries.insertBreed(null, breed.name)
+                dbRef.tableQueries.insertBreed(breed)
             }
         }
     }
@@ -51,10 +51,7 @@ class DatabaseHelper(
     suspend fun updateFavorite(breedId: Long, favorite: Boolean) {
         log.i { "Breed $breedId: Favorited $favorite" }
         dbRef.transactionWithContext(backgroundDispatcher) {
-            dbRef.tableQueries.updateFavorite(favorite.toLong(), breedId)
+            dbRef.tableQueries.updateFavorite(favorite, breedId)
         }
     }
 }
-
-fun Breed.isFavorited(): Boolean = this.favorite != 0L
-internal fun Boolean.toLong(): Long = if (this) 1L else 0L

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/DataState.kt
@@ -1,8 +1,0 @@
-package co.touchlab.kampkit.models
-
-data class DataState<out T>(
-    val data: T? = null,
-    val exception: String? = null,
-    val empty: Boolean = false,
-    val loading: Boolean = false
-)

--- a/shared/src/commonMain/sqldelight/co/touchlab/kampkit/db/Table.sq
+++ b/shared/src/commonMain/sqldelight/co/touchlab/kampkit/db/Table.sq
@@ -1,7 +1,7 @@
 CREATE TABLE Breed (
 id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
 name TEXT NOT NULL UNIQUE,
-favorite INTEGER NOT NULL DEFAULT 0
+favorite INTEGER AS Boolean NOT NULL DEFAULT 0
 );
 
 selectAll:
@@ -14,8 +14,8 @@ selectByName:
 SELECT * FROM Breed WHERE name = ?;
 
 insertBreed:
-INSERT OR IGNORE INTO Breed(id, name)
-VALUES (?,?);
+INSERT OR IGNORE INTO Breed(name)
+VALUES (?);
 
 deleteAll:
 DELETE FROM Breed;

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/BreedViewModelTest.kt
@@ -1,0 +1,258 @@
+package co.touchlab.kampkit
+
+import app.cash.turbine.FlowTurbine
+import app.cash.turbine.test
+import co.touchlab.kampkit.db.Breed
+import co.touchlab.kampkit.mock.ClockMock
+import co.touchlab.kampkit.mock.DogApiMock
+import co.touchlab.kampkit.models.BreedRepository
+import co.touchlab.kampkit.models.BreedViewModel
+import co.touchlab.kampkit.models.BreedViewState
+import co.touchlab.kampkit.response.BreedResult
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.StaticConfig
+import com.russhwolf.settings.MockSettings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.Clock
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+
+class BreedViewModelTest {
+    private var kermit = Logger(StaticConfig())
+    private var testDbConnection = testDbConnection()
+    private var dbHelper = DatabaseHelper(
+        testDbConnection,
+        kermit,
+        Dispatchers.Default
+    )
+    private val settings = MockSettings()
+    private val ktorApi = DogApiMock()
+
+    // Need to start at non-zero time because the default value for db timestamp is 0
+    private val clock = ClockMock(Clock.System.now())
+
+    private val repository: BreedRepository = BreedRepository(dbHelper, settings, ktorApi, kermit, clock)
+    private val viewModel by lazy { BreedViewModel(repository, kermit) }
+
+    companion object {
+        private val appenzeller = Breed(1, "appenzeller", false)
+        private val australianNoLike = Breed(2, "australian", false)
+        private val australianLike = Breed(2, "australian", true)
+        private val breedViewStateSuccessNoFavorite = BreedViewState(
+            breeds = listOf(appenzeller, australianNoLike)
+        )
+        private val breedViewStateSuccessFavorite = BreedViewState(
+            breeds = listOf(appenzeller, australianLike)
+        )
+        private val breedNames = breedViewStateSuccessNoFavorite.breeds?.map { it.name }.orEmpty()
+    }
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDbConnection.close()
+    }
+
+    @Test
+    fun `Get breeds without cache`() = runBlocking {
+        ktorApi.prepareResult(ktorApi.successResult())
+
+        viewModel.breedState.test {
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(BreedViewState(isLoading = true), BreedViewState(isEmpty = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Get breeds empty`() = runBlocking {
+        ktorApi.prepareResult(BreedResult(emptyMap(), "success"))
+
+        viewModel.breedState.test {
+            assertEquals(
+                BreedViewState(isEmpty = true),
+                awaitItemPrecededBy(BreedViewState(isLoading = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Get updated breeds with cache and preserve favorites`() = runBlocking {
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, clock.currentInstant.toEpochMilliseconds())
+
+        val successResult = ktorApi.successResult()
+        val resultWithExtraBreed = successResult.copy(message = successResult.message + ("extra" to emptyList()))
+        ktorApi.prepareResult(resultWithExtraBreed)
+
+        dbHelper.insertBreeds(breedNames)
+        dbHelper.updateFavorite(australianLike.id, true)
+
+        viewModel.breedState.test {
+            assertEquals(breedViewStateSuccessFavorite, awaitItemPrecededBy(BreedViewState(isLoading = true)))
+            expectNoEvents()
+
+            viewModel.refreshBreeds().join()
+            // id is 5 here because it incremented twice when trying to insert duplicate breeds
+            assertEquals(
+                BreedViewState(breedViewStateSuccessFavorite.breeds?.plus(Breed(5, "extra", false))),
+                awaitItemPrecededBy(breedViewStateSuccessFavorite.copy(isLoading = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Get updated breeds when stale and preserve favorites`() = runBlocking {
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, (clock.currentInstant - 2.hours).toEpochMilliseconds())
+
+        val successResult = ktorApi.successResult()
+        val resultWithExtraBreed = successResult.copy(message = successResult.message + ("extra" to emptyList()))
+        ktorApi.prepareResult(resultWithExtraBreed)
+
+        dbHelper.insertBreeds(breedNames)
+        dbHelper.updateFavorite(australianLike.id, true)
+
+        viewModel.breedState.test {
+            // id is 5 here because it incremented twice when trying to insert duplicate breeds
+            assertEquals(
+                BreedViewState(breedViewStateSuccessFavorite.breeds?.plus(Breed(5, "extra", false))),
+                awaitItemPrecededBy(BreedViewState(isLoading = true), breedViewStateSuccessFavorite)
+            )
+        }
+    }
+
+    @Test
+    fun `Toggle favorite cached breed`() = runBlocking {
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, clock.currentInstant.toEpochMilliseconds())
+
+        dbHelper.insertBreeds(breedNames)
+        dbHelper.updateFavorite(australianLike.id, true)
+
+        viewModel.breedState.test {
+            assertEquals(breedViewStateSuccessFavorite, awaitItemPrecededBy(BreedViewState(isLoading = true)))
+            expectNoEvents()
+
+            viewModel.updateBreedFavorite(australianLike).join()
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(breedViewStateSuccessFavorite.copy(isLoading = true))
+            )
+        }
+    }
+
+    @Test
+    fun `No web call if data is not stale`() = runBlocking {
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, clock.currentInstant.toEpochMilliseconds())
+        ktorApi.prepareResult(ktorApi.successResult())
+        dbHelper.insertBreeds(breedNames)
+
+        viewModel.breedState.test {
+            assertEquals(breedViewStateSuccessNoFavorite, awaitItemPrecededBy(BreedViewState(isLoading = true)))
+            assertEquals(0, ktorApi.calledCount)
+            expectNoEvents()
+
+            viewModel.refreshBreeds().join()
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(breedViewStateSuccessNoFavorite.copy(isLoading = true))
+            )
+            assertEquals(1, ktorApi.calledCount)
+        }
+    }
+
+    @Test
+    fun `Display API error on first run`() = runBlocking {
+        ktorApi.throwOnCall(RuntimeException("Test error"))
+
+        viewModel.breedState.test {
+            assertEquals(
+                BreedViewState(error = "Unable to download breed list"),
+                awaitItemPrecededBy(BreedViewState(isLoading = true), BreedViewState(isEmpty = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Ignore API error with cache`() = runBlocking {
+        dbHelper.insertBreeds(breedNames)
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, (clock.currentInstant - 2.hours).toEpochMilliseconds())
+        ktorApi.throwOnCall(RuntimeException("Test error"))
+
+        viewModel.breedState.test {
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(BreedViewState(isLoading = true))
+            )
+            expectNoEvents()
+
+            ktorApi.prepareResult(ktorApi.successResult())
+            viewModel.refreshBreeds().join()
+
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(breedViewStateSuccessNoFavorite.copy(isLoading = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Ignore API error on refresh with cache`() = runBlocking {
+        ktorApi.prepareResult(ktorApi.successResult())
+
+        viewModel.breedState.test {
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(BreedViewState(isLoading = true), BreedViewState(isEmpty = true))
+            )
+            expectNoEvents()
+
+            ktorApi.throwOnCall(RuntimeException("Test error"))
+            viewModel.refreshBreeds().join()
+
+            assertEquals(
+                breedViewStateSuccessNoFavorite,
+                awaitItemPrecededBy(breedViewStateSuccessNoFavorite.copy(isLoading = true))
+            )
+        }
+    }
+
+    @Test
+    fun `Show API error on refresh without cache`() = runBlocking {
+        settings.putLong(BreedRepository.DB_TIMESTAMP_KEY, clock.currentInstant.toEpochMilliseconds())
+        ktorApi.throwOnCall(RuntimeException("Test error"))
+
+        viewModel.breedState.test {
+            assertEquals(BreedViewState(isEmpty = true), awaitItemPrecededBy(BreedViewState(isLoading = true)))
+            expectNoEvents()
+
+            viewModel.refreshBreeds().join()
+            assertEquals(
+                BreedViewState(error = "Unable to refresh breed list"),
+                awaitItemPrecededBy(BreedViewState(isEmpty = true, isLoading = true))
+            )
+        }
+    }
+}
+
+// There's a race condition where intermediate states can get missed if the next state comes too fast.
+// This function addresses that by awaiting an item that may or may not be preceded by the specified other items
+private suspend fun FlowTurbine<BreedViewState>.awaitItemPrecededBy(vararg items: BreedViewState): BreedViewState {
+    var nextItem = awaitItem()
+    for (item in items) {
+        if (item == nextItem) {
+            nextItem = awaitItem()
+        }
+    }
+    return nextItem
+}

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/SqlDelightTest.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/SqlDelightTest.kt
@@ -1,6 +1,5 @@
 package co.touchlab.kampkit
 
-import co.touchlab.kampkit.db.Breed
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -16,7 +15,7 @@ class SqlDelightTest {
     private lateinit var dbHelper: DatabaseHelper
 
     private suspend fun DatabaseHelper.insertBreed(name: String) {
-        insertBreeds(listOf(Breed(id = 1, name = name, favorite = 0L)))
+        insertBreeds(listOf(name))
     }
 
     @BeforeTest
@@ -60,7 +59,7 @@ class SqlDelightTest {
             "Could not retrieve Breed by Id"
         )
         assertTrue(
-            newBreed.isFavorited(),
+            newBreed.favorite,
             "Favorite Did Not Save"
         )
     }

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/BreedCallbackViewModel.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/BreedCallbackViewModel.kt
@@ -14,9 +14,13 @@ class BreedCallbackViewModel(
 
     override val viewModel = BreedViewModel(breedRepository, log)
 
-    val breeds = viewModel.breeds.asCallbacks()
+    val breeds = viewModel.breedState.asCallbacks()
 
-    fun refreshBreeds() = viewModel.refreshBreeds()
+    fun refreshBreeds() {
+        viewModel.refreshBreeds()
+    }
 
-    fun updateBreedFavorite(breed: Breed) = viewModel.updateBreedFavorite(breed)
+    fun updateBreedFavorite(breed: Breed) {
+        viewModel.updateBreedFavorite(breed)
+    }
 }


### PR DESCRIPTION
<!--- [Issue-XYZ] Add issue number and title to Title above -->

<!-- Add issue link -->
Closes #190 

## Summary
- Remove generic `DataState` and replace with `BreedListState` for better generic handling in Swift
- Better (?) separation between Repository and ViewModel. The repository exposes raw data, and the viewmodel packages it into success/loading/error/empty states
- Tests can use jvm sqlite driver instead of robolectric (this avoids deadlocks that were happening with `runBlocking` and `viewModelScope` on robolectric)
- Database exposes favorite as a `Boolean` instead of an `Int`
- Rewritten tests for both Repository and ViewModel

