### PR TITLE
Use @StateObject instead of @ObservedObject to bind viewmodel to SwiftUI

### DIFF
--- a/ios/KaMPKitiOS/BreedListScreen.swift
+++ b/ios/KaMPKitiOS/BreedListScreen.swift
@@ -63,7 +63,7 @@ class ObservableBreedModel: ObservableObject {
 }
 
 struct BreedListScreen: View {
-    @ObservedObject
+    @StateObject
     var observableModel = ObservableBreedModel()
 
     var body: some View {


### PR DESCRIPTION
Using @ObservedObject would lead to bugs if the view also had @State properties, because changing the state would reinstantiate the viewmodel. This came up recently on a project where we stopped getting updates after a state change because the viewmodel was being recreated without calling `activate()` again.
