### PR TITLE
Fix capitalization of Xcode

### DIFF
--- a/docs/APP_BUILD.md
+++ b/docs/APP_BUILD.md
@@ -25,7 +25,7 @@ git clone https://github.com/touchlab/KaMPKit.git
 
 ### 3) Build iOS
 
-1. [Optional] Run gradle build. If you are more familiar with Android it may be easier to run the gradle build and confirm that the shared library builds properly before moving into XCode land, but this isn't necessary. The shared library will also build when run in XCode.
+1. [Optional] Run gradle build. If you are more familiar with Android it may be easier to run the gradle build and confirm that the shared library builds properly before moving into Xcode land, but this isn't necessary. The shared library will also build when run in Xcode.
    1. Open a Terminal window or use the one at the bottom Android Studio/IntelliJ. 
    1. Navigate to the project's root directory (`KaMPKit/` - not `KaMPKit/ios/` - which is iOS project's root directory). 
    1. Run the command `./gradlew build` which will build the shared library.

--- a/docs/DEBUGGING_KOTLIN_IN_XCODE.md
+++ b/docs/DEBUGGING_KOTLIN_IN_XCODE.md
@@ -6,7 +6,7 @@ By this point you should be able to build and run the KaMP Kit in iOS using Xcod
 The [Kotlin Native Xcode Plugin](https://github.com/touchlab/xcode-kotlin) adds basic highlighting, allows you to set breakpoints and includes llvm support to view data in the debug window. You can find the steps to install this plugin on its readMe, but it's as simple as running a couple of bash scripts.
 
 ### Kotlin Source in Xcode
-To take advantage of the plugin you will want to add references to your kotlin code in XCode. This will allow you to add breakpoints and edit kotlin without switching to Android Studio. You probably wont want to do your primary kotlin coding like this, but it's helpful when debugging.
+To take advantage of the plugin you will want to add references to your kotlin code in Xcode. This will allow you to add breakpoints and edit kotlin without switching to Android Studio. You probably wont want to do your primary kotlin coding like this, but it's helpful when debugging.
 
 To add the Kotlin source:
 1. Right click in the project explorer

--- a/docs/GENERAL_ARCHITECTURE.md
+++ b/docs/GENERAL_ARCHITECTURE.md
@@ -22,7 +22,7 @@ The KaMP kit is broken up into three different directories:
 
 The app directory holds the android version of the app, and all the android code. As a default, Android Studio will name the project "app" when creating it. Even though this can be confusing for kmp this is the default.
 
-Similarly the ios directory holds the iOS version of the app, which contains an XCode project and a Workspace. We want to use the workspace as it contains the shared library.
+Similarly the ios directory holds the iOS version of the app, which contains an Xcode project and a Workspace. We want to use the workspace as it contains the shared library.
 
 Finally the shared directory holds the shared code. The shared directory is actually an android library that is referenced from the app project. This library contains directories for the different platforms as well as directories for testing.
 


### PR DESCRIPTION
## Summary
Fixes four instances of a typo: Xcode is spelled with a lower-case c (see [Apple Developer](https://developer.apple.com/xcode/)).

## Fix
Fixed the spelling

## Testing
None (simple copy changes in docs)