### PR TITLE
update kermit to 1.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ ktor = "2.1.1"
 
 robolectric = "4.8.2"
 
-kermit = "1.1.3"
+kermit = "1.2.2"
 stately = "1.2.3"
 
 accompanist-swiperefresh = "0.25.1"


### PR DESCRIPTION
## Summary
Update to newer version of kermit. There's some other PRs open in kermit so probably worth waiting on this one until those make it into the next release then we can bump the version again
## Fix
Bump kermit version 

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- `xcodebuild -workspace ios/KaMPKitiOS.xcworkspace -scheme KaMPKitiOS 
    -sdk iphoneos -configuration Debug build -destination name="iPhone 8"`
- manual testing

