### PR TITLE
add collect with lifecycle helper

### DIFF
--- a/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
+++ b/app/src/main/java/co/touchlab/kampkit/android/ui/Composables.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kampkit.android.R
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.models.BreedViewModel
@@ -45,13 +45,7 @@ fun MainScreen(
     viewModel: BreedViewModel,
     log: Logger
 ) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val lifecycleAwareDogsFlow = remember(viewModel.breedState, lifecycleOwner) {
-        viewModel.breedState.flowWithLifecycle(lifecycleOwner.lifecycle)
-    }
-
-    @SuppressLint("StateFlowValueCalledInComposition") // False positive lint check when used inside collectAsState()
-    val dogsState by lifecycleAwareDogsFlow.collectAsState(viewModel.breedState.value)
+    val dogsState by viewModel.breedState.collectAsStateWithLifecycle()
 
     MainScreenContent(
         dogsState = dogsState,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ android-desugaring = "1.1.8" # Don't bump to 1.2.x until AGP is 7.3.x
 androidx-core = "1.8.0"
 androidx-test-junit = "1.1.3"
 androidx-activity-compose = "1.5.1"
-androidx-lifecycle = "2.5.1"
+androidx-lifecycle = "2.6.0-beta01"
 
 junit = "4.13.2"
 
@@ -42,6 +42,7 @@ android-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.re
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
@@ -98,6 +99,7 @@ app-ui = [
     "compose-compiler",
     "androidx-core",
     "androidx-lifecycle-runtime",
+    "androidx-lifecycle-runtime-compose",
     "androidx-lifecycle-viewmodel",
     "compose-ui",
     "compose-tooling",


### PR DESCRIPTION
## Summary
Use new `collectAsStateWithLifecycle` function to collect stateflows rather than than manual lifecycle hook. Comes from new rec for collecting https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3 

## Testing
<!-- Remove any lines that were not performed -->
- `./gradlew :app:build`
- `./gradlew :shared:build`
- manual testing
