### PR TITLE
Update library versions

### DIFF
--- a/.idea/inspectionProfiles/ktlint.xml
+++ b/.idea/inspectionProfiles/ktlint.xml
@@ -2,7 +2,42 @@
   <profile version="1.0">
     <option name="myName" value="ktlint" />
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="MarkdownUnresolvedFileReference" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>
 </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,7 @@ android {
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    packagingOptions {
-        resources.excludes.add("META-INF/*.kotlin_module")
-    }
+
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
@@ -34,11 +32,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
 
     composeOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
     kotlin("multiplatform") version libs.versions.kotlin.get() apply false
     kotlin("plugin.serialization") version libs.versions.kotlin.get() apply false
-    id("com.squareup.sqldelight") version libs.versions.sqlDelight.get() apply false
+    id("app.cash.sqldelight") version libs.versions.sqlDelight.get() apply false
     id("com.android.library") version libs.versions.android.gradle.plugin.get() apply false
 }
 

--- a/docs/GENERAL_ARCHITECTURE.md
+++ b/docs/GENERAL_ARCHITECTURE.md
@@ -10,7 +10,6 @@ This doc goes over the overall architecture of the app, the libraries usage and 
   * [Ktor](#Ktor) - Networking
   * [Multiplatform Settings](#Multiplatform-Settings) - Settings
   * [Koin](#Koin) - Dependency Injection
-  * [Stately](#Stately) - State Utility
 * [Testing](#Testing)
 
 ## Structure of the Project
@@ -104,7 +103,6 @@ Below is some information about some of the libraries used in the project.
 * [Ktor](#Ktor)
 * [Multiplatform Settings](#Multiplatform-Settings)
 * [Koin](#Koin)
-* [Stately](#Stately)
 * [Turbine](#Turbine)
 
 ### SqlDelight
@@ -143,15 +141,6 @@ Documentation: https://insert-koin.io/
 Usage in the project: *commonMain/kotlin/co/touchlab/kampkit/Koin.kt*
 
 Koin is a lightweight dependency injection framework. It is being used in the *koin.kt* file to inject modules into the BreedModel. You can tell which variables are being injected in the BreedModel because they are being set using `by inject()`. In our implementation we are separating our injections into two different modules: the `coreModule` and the `platformModule`. As you can guess the platformModule contains injections requiring platform specific implementations (SqlDelight and Multiplatform Settings). The coreModule contains the Ktor implementation and the Database Helper, which actually takes from the platformModule.
-
-### Stately
-Documentation: https://github.com/touchlab/Stately
-Stately is a state utility library used to help with state management in Kotlin Multiplatform (Made
-by us!).
-
-**Note:** Threading in K/N can be hard to grasp at first and this document isn't the place to go into it
-in detail. If you want to find out more about thread check out this post 
-[here](https://medium.com/@kpgalligan/kotlin-native-stranger-threads-ep-2-208523d63c8f)
 
 ## Testing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx3g
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -19,8 +15,5 @@ android.useAndroidX=true
 kotlin.code.style=official
 # Tell the KMM plugin where the iOS project lives
 xcodeproj=./ios
-# New memory model
-kotlin.native.binary.memoryModel=experimental
-kotlin.native.cacheKind.iosX64=none
 # New Android source-set layout
 kotlin.mpp.androidSourceSetLayoutVersion=2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.8.0"
+kotlin = "1.8.21"
 
 ## SDK Versions
 minSdk = "21"
@@ -7,41 +7,40 @@ targetSdk = "33"
 compileSdk = "33"
 
 # Dependencies
-android-gradle-plugin = "7.4.1"
-ktlint-gradle = "11.2.0"
-gradle-versions = "0.42.0"
+android-gradle-plugin = "7.4.2"
+ktlint-gradle = "11.4.2"
+gradle-versions = "0.47.0"
 
-compose = "1.4.0-alpha03"
-composeCompiler = "1.4.0-dev-k1.8.0-33c0ad36f83"
+compose = "1.4.3"
+composeCompiler = "1.4.7"
 
-android-desugaring = "1.1.8" # Don't bump to 1.2.x until AGP is 7.3.x
-androidx-core = "1.9.0"
-androidx-test-junit = "1.1.3"
-androidx-activity-compose = "1.5.1"
-androidx-lifecycle = "2.5.1"
+android-desugaring = "2.0.3"
+androidx-core = "1.10.1"
+androidx-test-junit = "1.1.5"
+androidx-activity-compose = "1.7.2"
+androidx-lifecycle = "2.6.1"
 
 junit = "4.13.2"
 
-coroutines = "1.6.4"
+coroutines = "1.7.0"
 kotlinx-datetime = "0.4.0"
-ktor = "2.1.1"
+ktor = "2.3.1"
 
-robolectric = "4.8.2"
+robolectric = "4.10.3"
 
-kermit = "1.2.2"
-stately = "1.2.3"
+kermit = "2.0.0-RC3"
 
-accompanist-swiperefresh = "0.25.1"
-koin = "3.2.0"
-multiplatformSettings = "1.0.0-alpha01"
-turbine = "0.12.1"
-sqlDelight = "1.5.5"
+koin = "3.4.1"
+multiplatformSettings = "1.0.0"
+turbine = "1.0.0"
+sqlDelight = "2.0.0-rc01"
 
 [libraries]
 android-desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "android-desugaring" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-test-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-junit" }
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
@@ -53,8 +52,6 @@ compose-activity = { module = "androidx.activity:activity-compose", version.ref 
 
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
-
-google-accompanist-swipeRefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "accompanist-swiperefresh" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 
@@ -77,14 +74,14 @@ multiplatformSettings-test = { module = "com.russhwolf:multiplatform-settings-te
 
 roboelectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
-sqlDelight-android = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelight" }
-sqlDelight-jvm = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
-sqlDelight-coroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
-sqlDelight-native = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqlDelight" }
-sqlDelight-runtime = { module = "com.squareup.sqldelight:runtime", version.ref = "sqlDelight" }
+sqlDelight-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
+sqlDelight-jvm = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
+sqlDelight-coroutinesExt = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
+sqlDelight-native = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
+sqlDelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqlDelight" }
 
 touchlab-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
-touchlab-stately = { module = "co.touchlab:stately-common", version.ref = "stately" }
+touchlab-kermit-simple = { module = "co.touchlab:kermit-simple", version.ref = "kermit" }
 
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -99,12 +96,12 @@ app-ui = [
     "androidx-core",
     "androidx-lifecycle-runtime",
     "androidx-lifecycle-viewmodel",
+    "androidx-lifecycle-compose",
     "compose-ui",
     "compose-tooling",
     "compose-foundation",
     "compose-material",
-    "compose-activity",
-    "google-accompanist-swipeRefresh"
+    "compose-activity"
 ]
 ktor-common = ["ktor-client-core", "ktor-client-logging", "ktor-client-serialization", "ktor-client-contentNegotiation"]
 shared-commonTest = [

--- a/ios/Pods/Pods.xcodeproj/project.pbxproj
+++ b/ios/Pods/Pods.xcodeproj/project.pbxproj
@@ -257,8 +257,8 @@
 		46EB2E00000000 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1300;
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
 			};
 			buildConfigurationList = 46EB2E00000030 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 10.0";

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,8 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
     }
 }
 
 include(":app", ":shared")
 rootProject.name = "KaMPKit"
-
-enableFeaturePreview("VERSION_CATALOGS")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,14 +5,13 @@ plugins {
     kotlin("native.cocoapods")
     kotlin("plugin.serialization")
     id("com.android.library")
-    id("com.squareup.sqldelight")
+    id("app.cash.sqldelight")
 }
 
 android {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     testOptions {
@@ -51,7 +50,6 @@ kotlin {
                 implementation(libs.coroutines.core)
                 implementation(libs.sqlDelight.coroutinesExt)
                 implementation(libs.bundles.ktor.common)
-                implementation(libs.touchlab.stately)
                 implementation(libs.multiplatformSettings.common)
                 implementation(libs.kotlinx.dateTime)
                 api(libs.touchlab.kermit)
@@ -78,6 +76,7 @@ kotlin {
             dependencies {
                 implementation(libs.sqlDelight.native)
                 implementation(libs.ktor.client.ios)
+                api(libs.touchlab.kermit.simple)
             }
         }
         val iosTest by getting
@@ -100,6 +99,7 @@ kotlin {
         framework {
             isStatic = false // SwiftUI preview requires dynamic framework
             linkerOpts("-lsqlite3")
+            export(libs.touchlab.kermit.simple)
         }
         ios.deploymentTarget = "12.4"
         podfile = project.file("../ios/Podfile")
@@ -107,7 +107,7 @@ kotlin {
 }
 
 sqldelight {
-    database("KaMPKitDb") {
-        packageName = "co.touchlab.kampkit.db"
+    databases.create("KaMPKitDb") {
+        packageName.set("co.touchlab.kampkit.db")
     }
 }

--- a/shared/src/androidMain/kotlin/co/touchlab/kampkit/KoinAndroid.kt
+++ b/shared/src/androidMain/kotlin/co/touchlab/kampkit/KoinAndroid.kt
@@ -1,10 +1,10 @@
 package co.touchlab.kampkit
 
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import co.touchlab.kampkit.db.KaMPKitDb
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.SharedPreferencesSettings
-import com.squareup.sqldelight.android.AndroidSqliteDriver
-import com.squareup.sqldelight.db.SqlDriver
 import io.ktor.client.engine.okhttp.OkHttp
 import org.koin.core.module.Module
 import org.koin.dsl.module

--- a/shared/src/androidUnitTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
+++ b/shared/src/androidUnitTest/kotlin/co/touchlab/kampkit/TestUtilAndroid.kt
@@ -1,20 +1,8 @@
 package co.touchlab.kampkit
 
-import android.app.Application
-import androidx.test.core.app.ApplicationProvider
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import co.touchlab.kampkit.db.KaMPKitDb
-import com.squareup.sqldelight.android.AndroidSqliteDriver
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 
-internal actual fun testDbConnection(): SqlDriver {
-    // Try to use the android driver (which only works if we're on robolectric).
-    // Fall back to jdbc if that fails.
-    return try {
-        val app = ApplicationProvider.getApplicationContext<Application>()
-        AndroidSqliteDriver(KaMPKitDb.Schema, app, "kampkitdb")
-    } catch (exception: IllegalStateException) {
-        JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-            .also { KaMPKitDb.Schema.create(it) }
-    }
-}
+internal actual fun testDbConnection(): SqlDriver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    .also { KaMPKitDb.Schema.create(it) }

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/DatabaseHelper.kt
@@ -1,12 +1,12 @@
 package co.touchlab.kampkit
 
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import app.cash.sqldelight.db.SqlDriver
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.db.KaMPKitDb
 import co.touchlab.kampkit.sqldelight.transactionWithContext
 import co.touchlab.kermit.Logger
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.runtime.coroutines.asFlow
-import com.squareup.sqldelight.runtime.coroutines.mapToList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/ktor/DogApiImpl.kt
@@ -1,7 +1,6 @@
 package co.touchlab.kampkit.ktor
 
 import co.touchlab.kampkit.response.BreedResult
-import co.touchlab.stately.ensureNeverFrozen
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
@@ -39,10 +38,6 @@ class DogApiImpl(private val log: KermitLogger, engine: HttpClientEngine) : DogA
             requestTimeoutMillis = timeout
             socketTimeoutMillis = timeout
         }
-    }
-
-    init {
-        ensureNeverFrozen()
     }
 
     override suspend fun getJsonFromApi(): BreedResult {

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedRepository.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedRepository.kt
@@ -4,7 +4,6 @@ import co.touchlab.kampkit.DatabaseHelper
 import co.touchlab.kampkit.db.Breed
 import co.touchlab.kampkit.ktor.DogApi
 import co.touchlab.kermit.Logger
-import co.touchlab.stately.ensureNeverFrozen
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.Clock
@@ -21,10 +20,6 @@ class BreedRepository(
 
     companion object {
         internal const val DB_TIMESTAMP_KEY = "DbTimestampKey"
-    }
-
-    init {
-        ensureNeverFrozen()
     }
 
     fun getBreeds(): Flow<List<Breed>> = dbHelper.selectAllItems()

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedViewModel.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/models/BreedViewModel.kt
@@ -12,9 +12,8 @@ import kotlinx.coroutines.launch
 
 class BreedViewModel(
     private val breedRepository: BreedRepository,
-    log: Logger
+    private val log: Logger
 ) : ViewModel() {
-    private val log = log.withTag("BreedCommonViewModel")
 
     private val mutableBreedState: MutableStateFlow<BreedViewState> =
         MutableStateFlow(BreedViewState(isLoading = true))

--- a/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
+++ b/shared/src/commonMain/kotlin/co/touchlab/kampkit/sqldelight/CoroutinesExtensions.kt
@@ -1,7 +1,7 @@
 package co.touchlab.kampkit.sqldelight
 
-import com.squareup.sqldelight.Transacter
-import com.squareup.sqldelight.TransactionWithoutReturn
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.TransactionWithoutReturn
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 

--- a/shared/src/commonTest/kotlin/co/touchlab/kampkit/TestUtil.kt
+++ b/shared/src/commonTest/kotlin/co/touchlab/kampkit/TestUtil.kt
@@ -1,5 +1,5 @@
 package co.touchlab.kampkit
 
-import com.squareup.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlDriver
 
 internal expect fun testDbConnection(): SqlDriver

--- a/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
+++ b/shared/src/iosMain/kotlin/co/touchlab/kampkit/KoinIOS.kt
@@ -1,11 +1,11 @@
 package co.touchlab.kampkit
 
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import co.touchlab.kampkit.db.KaMPKitDb
 import co.touchlab.kermit.Logger
 import com.russhwolf.settings.NSUserDefaultsSettings
 import com.russhwolf.settings.Settings
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 import io.ktor.client.engine.darwin.Darwin
 import org.koin.core.Koin
 import org.koin.core.KoinApplication

--- a/shared/src/iosTest/kotlin/co/touchlab/kampkit/TestUtilIOS.kt
+++ b/shared/src/iosTest/kotlin/co/touchlab/kampkit/TestUtilIOS.kt
@@ -1,24 +1,9 @@
 package co.touchlab.kampkit
 
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.native.inMemoryDriver
 import co.touchlab.kampkit.db.KaMPKitDb
-import co.touchlab.sqliter.DatabaseConfiguration
-import com.squareup.sqldelight.db.SqlDriver
-import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
-import com.squareup.sqldelight.drivers.native.wrapConnection
 
 internal actual fun testDbConnection(): SqlDriver {
-    val schema = KaMPKitDb.Schema
-    return NativeSqliteDriver(
-        DatabaseConfiguration(
-            name = "kampkitdb",
-            version = schema.version,
-            create = { connection ->
-                wrapConnection(connection) { schema.create(it) }
-            },
-            upgrade = { connection, oldVersion, newVersion ->
-                wrapConnection(connection) { schema.migrate(it, oldVersion, newVersion) }
-            },
-            inMemory = true
-        )
-    )
+    return inMemoryDriver(KaMPKitDb.Schema)
 }


### PR DESCRIPTION
Also includes some code changes:
- Removes Stately, which we were only using for `ensureNeverFrozen()` calls that no longer do anything.
- Includes some import and config updates to account for SqlDelight and Kermit changes
- Includes some compose refactors to account for swipefrefresh and lifecycle changes

This replaces #294, and fixes #298 and #291